### PR TITLE
Added access token usage and storage

### DIFF
--- a/frontEnd/android/app/src/main/AndroidManifest.xml
+++ b/frontEnd/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="milestone_3"

--- a/frontEnd/lib/imports/globals.dart
+++ b/frontEnd/lib/imports/globals.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+
+class Globals{
+  static Color secondaryColor = Color(0xff106126);
+  var username;
+}

--- a/frontEnd/lib/imports/user_tokens_manager.dart
+++ b/frontEnd/lib/imports/user_tokens_manager.dart
@@ -1,4 +1,9 @@
-import 'response_item.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:http/http.dart';
+import 'dart:convert';
+import 'globals.dart';
+import 'dart:async';
+import 'package:flutter/material.dart';
 
 final String userPoolUrl = "https://pocket-poll.auth.us-east-2.amazoncognito.com";
 final String clientId = "7eh4otm1r5p351d1u9j3h3rf1o";
@@ -9,44 +14,139 @@ final String tokenEndpoint = "/token?";
 final String userInfoEndpoint = "/userInfo?";
 final String logoutEndpoint = "/logout?";
 
-ResponseItem logUserIn() {
-  bool success = false;
-  String actionMessage = "function not implemented";
+//One option to consider for the future is making one SharedPreferences variable
+//as a global variable and just use it for all local storage, but for now I'll keep
+//the scope within the context of tokens.
+SharedPreferences _tokens;
+final String accessTokenKey = "access";   //_tokens is like a Map, so we declare
+final String refreshTokenKey = "refresh"; //the keys for the tokens here.
+final String idTokenKey = "id";
+bool gotTokens = false;
 
-  //attempt to log user in with cognito
 
-  //if login is successful, call getUserTokens with parsed code from Location header
+Future<bool> hasValidTokensSet() async {
+  //check to see if the tokens are stored in local memory and to see if they can get
+  //data from the user endpoint. if not, try to refresh. if can't refresh, return false
 
-  return new ResponseItem(success, actionMessage);
-}
+  //debugPrint("NOW IN hasValidTokensSet");
+  try {
+    //Initialize the SharedPreferences object and check for the existence of
+    //the tokens.
+    _tokens = await SharedPreferences.getInstance();
+    if (_tokens.containsKey(accessTokenKey) &&
+        _tokens.containsKey(refreshTokenKey) &&
+        _tokens.containsKey(idTokenKey)) {
+      //debugPrint("THE KEYS DO EXIST IN SHARED PREFERENCES");
 
-bool hasValidTokensSet() {
-  //need a check to see if they're stored in local memory and to see if they can get
-  //data from the user endpoint, if not, try to refresh, if can't refresh, return false
+      //Set up the HTTP GET request.
+      Map<String, String> headers = {
+        "Authorization": "Bearer " + _tokens.getString(accessTokenKey)
+      };
+      Response response = await get(
+          userPoolUrl + "/oauth2/userInfo", headers: headers);
+
+      if (response.statusCode == 200) {
+        var body = json.decode(response.body);
+        //print(body);
+        Globals().username = body['username']; //Store the username for other functions.
+        return true;
+      } else {
+        //The access token didn't work, so refresh and try again. If it fails a
+        //second time, return false so that the user is taken back to the login.
+        debugPrint("THE ACCESS TOKEN DID NOT WORK, ATTEMPTING REFRESH");
+        headers.clear();
+        await refreshUserTokens();
+        headers = {
+          "Authorization": "Bearer " + _tokens.getString(accessTokenKey)
+        };
+        await get(userPoolUrl + "/oauth2/userInfo", headers: headers);
+        if (response.statusCode == 200) {
+          debugPrint("THE REFRESHED ACCESS TOKEN WORKED");
+          var body = json.decode(response.body);
+          Globals().username = body['username'];
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+  }
+  catch (e) {
+    debugPrint("THE KEYS DO NOT EXIST");
+    debugPrint(e.toString());
+    return false;
+  }
   return false;
 }
 
-ResponseItem registerNewUser() {
-  bool success = false;
-  String actionMessage = "function not implemented";
-
-  //attempt to create user account with cognito
-
-  //if adding user is successful, add call to 'insertNewUser' located in users_manager.dart
-
-  return new ResponseItem(success, actionMessage);
-}
-
-void getUserTokens() {
+Future<void> getUserTokens(String authorizationCode) async {
   //This will take the 'AUTHORIZATION_CODE' from the authorize endpoint and use
-  //it to get tokens from the token endpoint. Then call storeUserTokens to store these tokens
+  //it to get tokens from the token endpoint, then store them via storeUserTokens.
+
+  //debugPrint("NOW IN getUserTokens");
+
+  Map<String, String> headers = {
+    "Content-Type": "application/x-www-form-urlencoded"
+  };
+  String data = 'grant_type=authorization_code&client_id=' +
+      clientId + '&code=' + authorizationCode + '&redirect_uri=' +
+      redirectUri;
+  //debugPrint(data);
+
+  Response response = await post(
+      userPoolUrl + "/oauth2/token", headers: headers,
+      body: data);
+
+  if (response.statusCode == 200) {
+    //debugPrint("SUCCESS GET TOKEN WITH RESPONSE CODE " + response.statusCode.toString());
+    var body = json.decode(response.body);
+    //debugPrint(body.toString());
+    storeUserTokens(
+        body['access_token'], body['refresh_token'], body['id_token']);
+    gotTokens = true;
+  } else {
+    debugPrint("FAILED GET TOKEN RESPONSE WITH CODE: " + response.statusCode.toString());
+    debugPrint(response.toString());
+    }
 }
 
-void refreshUserTokens() {
+Future<void> refreshUserTokens() async {
   //Use the stored refresh token to get new tokens and then call storeUserTokens to store the new tokens
   //hint, don't overwrite the refresh token, that one token can be used many times and you only get it once
+
+  //debugPrint("NOW IN refreshUserTokens");
+  String refreshToken = _tokens.getString(refreshTokenKey);
+  //print("refresh token: " + refreshToken);
+  //print("access token before refresh: " + _tokens.getString(accessTokenKey));
+
+  Map<String, String> headers = {
+    "Content-Type": "application/x-www-form-urlencoded"
+  };
+  String data = 'grant_type=refresh_token&client_id=' +
+      clientId + '&refresh_token=' + refreshToken;
+
+  Response response = await post(
+    userPoolUrl + "/oauth2/token", headers: headers,
+    body: data);
+
+  if (response.statusCode == 200) {
+    //debugPrint("THE REFRESH WORKED WITH STATUS CODE: " + response.statusCode.toString());
+    //print("access token before refresh: " + _tokens.getString(accessTokenKey));
+    var body = json.decode(response.body);
+    storeUserTokens(body['access_token'], refreshToken, body['id_token']);
+  } else {
+      debugPrint("FAILED REFRESH RESPONSE WITH CODE: " + response.statusCode.toString());
+      debugPrint(response.toString());
+      debugPrint(response.body);
+    }
 }
 
-void storeUserTokens() {
-
+void storeUserTokens(String accessToken, String refreshToken, String idToken) {
+  //debugPrint("NOW IN storeUserTokens");
+  //debugPrint("access token: " + accessToken);
+  //debugPrint("refresh token: " + refreshToken);
+  //debugPrint("id token: " + idToken);
+  _tokens.setString(accessTokenKey, accessToken);
+  _tokens.setString(idTokenKey, idToken);
+  _tokens.setString(refreshTokenKey, refreshToken);
 }

--- a/frontEnd/lib/login_page.dart
+++ b/frontEnd/lib/login_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_webview_plugin/flutter_webview_plugin.dart';
+import 'imports/user_tokens_manager.dart';
 
 import 'main.dart';
 
@@ -45,21 +46,30 @@ class _LoginScreenState extends State<LoginScreen> {
         });
 
     // Add a listener to on url changed
-    _onUrlChanged = flutterWebviewPlugin.onUrlChanged.listen((String url) {
-      if (mounted) {
-        setState(() {
+    _onUrlChanged = flutterWebviewPlugin.onUrlChanged.listen((String url) async {
+      //if (mounted) {
+        //setState(() {
           int codeIndex = url.indexOf("code");
 
           if (url.startsWith("https://www.google.com") && codeIndex != -1) {
             //login was successful, parse and store code
             String code = url.substring(codeIndex + 5);
-
-            //if storage is successful run these lines, otherwise we'll probably want to do sometype of error page
-            flutterWebviewPlugin.close();
-            Route route = MaterialPageRoute(builder: (context) => MyApp());
-            Navigator.pushReplacement(context, route);
+            await getUserTokens(code);
+            //setState is called after the asynchronous function so that the
+            //state is updated after the execution of said function is complete.
+            if (mounted) {
+              setState(() {
+              if (gotTokens) {
+                //if storage is successful run these lines, otherwise we'll probably want to do some type of error page
+                flutterWebviewPlugin.close();
+                Route route = MaterialPageRoute(builder: (context) => MyApp());
+                Navigator.pushReplacement(context, route);
+              } else {
+                flutterWebviewPlugin.close(); //TODO: proper error page
+              }
+              });
           }
-        });
+        //});
       }
     });
   }
@@ -67,7 +77,6 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     String loginEndpoint = "https://pocket-poll.auth.us-east-2.amazoncognito.com/login?client_id=7eh4otm1r5p351d1u9j3h3rf1o&response_type=code&redirect_uri=https://google.com";
-
     return new WebviewScaffold(
         url: loginEndpoint,
         appBar: new AppBar(

--- a/frontEnd/lib/main.dart
+++ b/frontEnd/lib/main.dart
@@ -1,38 +1,58 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'add_value_pair.dart';
 import 'imports/dev_testing_manager.dart';
 import 'imports/pair.dart';
 import 'imports/user_tokens_manager.dart';
+import 'imports/globals.dart';
 import 'login_page.dart';
 import 'web_view_container.dart';
 
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
-  final WebViewContainer webViewContainer = new WebViewContainer("https://pocket-poll.auth.us-east-2.amazoncognito.com/login?client_id=7eh4otm1r5p351d1u9j3h3rf1o&response_type=code&redirect_uri=https://google.com");
 
   @override
   Widget build(BuildContext context) {
-    if (!hasValidTokensSet()) {
-      return MaterialApp(
-        title: 'Flutter Demo',
-        theme: ThemeData(
-          primarySwatch: Colors.green,
-
-
-        ),
-        home: LoginScreen(),
-      );
-    } else {
-      return MaterialApp(
-        title: 'Flutter Demo',
-        theme: ThemeData(
-          primarySwatch: Colors.green,
-        ),
-        home: MyAppContents(dbPairs: this.getAllPairsWidget()),
-      );
-    }
+    return new Container(
+      //We use a FutureBuilder here since the display of the widget depends on
+      //the asynchronous function hasValidTokensSet being able to fully execute
+      //and return a Future<bool>.
+      child: new FutureBuilder<bool>(
+        future: hasValidTokensSet(),
+        builder: (BuildContext context, AsyncSnapshot snapshot) {
+          //If the function to set the hasValidTokens boolean hasn't finished
+          //yet, then display a circular progress indicator.
+          if (!snapshot.hasData) {
+            return Center(
+                child: new CircularProgressIndicator()
+                );
+          } else {
+            //If the tokens are not valid or don't exist, open the login page.
+            //Otherwise, skip the login page.
+            if (!snapshot.data) {
+              return MaterialApp(
+                title: 'Flutter Demo',
+                theme: ThemeData(
+                  primarySwatch: Colors.green,
+                ),
+                home: LoginScreen(),
+              );
+            } else {
+              return MaterialApp(
+                title: 'Flutter Demo',
+                theme: ThemeData(
+                  primarySwatch: Colors.green,
+                ),
+                home: MyAppContents(dbPairs: this.getAllPairsWidget()),
+              );
+            }
+          }
+        }
+      )
+    );
   }
 
   Future<Widget> getAllPairsWidget() async {

--- a/frontEnd/pubspec.yaml
+++ b/frontEnd/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
     sdk: flutter
   http: ^0.12.0+2
   flutter_webview_plugin: ^0.3.8
+  shared_preferences: ^0.5.4
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Now the app can take the authorization code from an initial login and use it to acquire an access token, an ID token, and a refresh token. Then all three tokens are stored locally using SharedPreferences.

Testing was done both with an existing user (dummy_user) and by creating a new user (dummy_two) within the app, and then after logging in, I closed the app and reopened it to test if the tokens persisted properly (in other words, if you go straight to the database page). 

For testing the refresh token, I temporarily changed the floating action button on the database page to call refreshUserTokens() and printed the values of the tokens before and after the refresh. Once I verified that access token and ID token were both changed, I reverted the floating action button back to its original functionality.

All testing was done directly on my Android phone, both with a debug .apk and a release .apk. To get it to work on the release apk, I had to add a dependency to AndroidManifest.xml that allows for internet access.