### PR TITLE
Added the ability to pull categories from a specific group

### DIFF
--- a/backEnd/src/main/java/imports/CategoriesManager.java
+++ b/backEnd/src/main/java/imports/CategoriesManager.java
@@ -175,6 +175,9 @@ public class CategoriesManager extends DatabaseAccessManager {
       categoryIds = this.usersManager.getAllCategoryIds(username);
     } else if (jsonMap.containsKey(RequestFields.CATEGORY_IDS)) {
       categoryIds = (List<String>) jsonMap.get(RequestFields.CATEGORY_IDS);
+    } else if (jsonMap.containsKey(this.groupsManager.getPrimaryKeyIndex())) {
+      String groupId = (String) jsonMap.get(this.groupsManager.getPrimaryKeyIndex());
+      categoryIds = this.groupsManager.getAllCategoryIds(groupId);
     } else {
       success = false;
       resultMessage = "Error: query key not defined.";

--- a/backEnd/src/main/java/imports/GroupsManager.java
+++ b/backEnd/src/main/java/imports/GroupsManager.java
@@ -254,6 +254,16 @@ public class GroupsManager extends DatabaseAccessManager {
     //add these to the 'actions' Collection
   }
 
+  public List<String> getAllCategoryIds(String groupId) {
+    Item dbData = super
+        .getItem(new GetItemSpec().withPrimaryKey(super.getPrimaryKeyIndex(), groupId));
+
+    Map<String, Object> dbDataMap = dbData.asMap(); // specific group record as a map
+    Map<String, String> categoryMap = (Map<String, String>) dbDataMap.get(CATEGORIES);
+
+    return new ArrayList<String>(categoryMap.keySet());
+  }
+
   // This function is called when a category is deleted and updates each item in the groups table
   // that was linked to the category accordingly.
   public void removeCategoryFromGroups(List<String> groupIds, String categoryId) {


### PR DESCRIPTION
Since I need to be able to pull the categories associated with a specific group when creating a new event for said group, I quickly wrote some back end code that accomplishes this. To test it, I used my development lambda function and had it pull the categories linked to one of the groups in our database, then verified that all the resulting categories were correct.