### PR TITLE
fixed bug on event resolution side of things

### DIFF
--- a/backEnd/src/main/java/handlers/PendingEventResolutionHandler.java
+++ b/backEnd/src/main/java/handlers/PendingEventResolutionHandler.java
@@ -7,16 +7,23 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Map;
+import utilities.ExceptionHelper;
+import utilities.IOStreamsHelper;
 import utilities.JsonParsers;
+import utilities.ResultStatus;
 
 public class PendingEventResolutionHandler implements RequestStreamHandler {
   public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
       throws IOException {
+    ResultStatus resultStatus = new ResultStatus();
     try {
       Map<String, Object> jsonMap = JsonParsers.parseInput(inputStream);
-      DatabaseManagers.PENDING_EVENTS_MANAGER.processPendingEvent(jsonMap);
+      resultStatus = DatabaseManagers.PENDING_EVENTS_MANAGER.processPendingEvent(jsonMap);
     } catch (Exception e) {
       //TODO add log message https://github.com/SCCapstone/decision_maker/issues/82
+      resultStatus.resultMessage = ExceptionHelper.getStackTrace(e);
     }
+
+    IOStreamsHelper.writeToOutput(outputStream, resultStatus.toString());
   }
 }

--- a/backEnd/src/main/java/handlers/PendingEventsScanningHandler.java
+++ b/backEnd/src/main/java/handlers/PendingEventsScanningHandler.java
@@ -8,10 +8,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public class PendingEventsScanningHandler implements RequestStreamHandler {
+    public static final String SCANNER_ID_ENV_KEY = "ScannerId";
+
     public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
             throws IOException {
         try {
-            String scannerId = System.getenv("ScannerId");
+            String scannerId = System.getenv(SCANNER_ID_ENV_KEY);
             DatabaseManagers.PENDING_EVENTS_MANAGER.scanPendingEvents(scannerId);
         } catch (Exception e) {
             //TODO add log message https://github.com/SCCapstone/decision_maker/issues/82

--- a/backEnd/src/main/java/imports/DatabaseAccessManager.java
+++ b/backEnd/src/main/java/imports/DatabaseAccessManager.java
@@ -16,7 +16,7 @@ import com.amazonaws.services.dynamodbv2.model.TransactGetItemsRequest;
 import com.amazonaws.services.dynamodbv2.model.TransactGetItemsResult;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsRequest;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsResult;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 
 public class DatabaseAccessManager {
 
@@ -25,7 +25,7 @@ public class DatabaseAccessManager {
   private final String primaryKeyIndex;
   private final Regions region;
   private final AmazonDynamoDBClient client;
-  private final SimpleDateFormat dbDateFormatter = new SimpleDateFormat("YYYY-MM-dd HH:mm:ss");
+  private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
   public DatabaseAccessManager(final String tableName, final String primaryKeyIndex,
       final Regions regions) {
@@ -59,8 +59,8 @@ public class DatabaseAccessManager {
     return this.primaryKeyIndex;
   }
 
-  public SimpleDateFormat getDbDateFormatter() {
-    return this.dbDateFormatter;
+  public DateTimeFormatter getDateTimeFormatter() {
+    return this.dateTimeFormatter;
   }
 
   public Item getItem(final GetItemSpec getItemSpec) {


### PR DESCRIPTION
## Summary
The purpose of these changes is to fix a bug with the even resolution system. Turns out the java.utils.Date class isn't thread safe ([more info on that here](https://stackoverflow.com/questions/4021151/java-dateformat-is-not-threadsafe-what-does-this-leads-to)). I updated our back end date management system to use the newer thread safe LocalDateTime class. After testing I believe this works now. 

## Testing
I created a bunch of new events and then manually ran the event scanner script and logged which dates were past the current date. This showed the correct output for what was supposed to be processed. In addition, I then changed some of the later dates to be older than the current time and those got processed accordingly.