### PR TITLE
enabled back end active user emulation to make testing easier

### DIFF
--- a/backEnd/src/main/java/handlers/CategoriesPostHandler.java
+++ b/backEnd/src/main/java/handlers/CategoriesPostHandler.java
@@ -28,7 +28,8 @@ public class CategoriesPostHandler implements
 
             if (!payloadJsonMap.containsKey(RequestFields.ACTIVE_USER)) {
               payloadJsonMap
-                  .put(RequestFields.ACTIVE_USER, GetActiveUser.getActiveUserFromRequest(request));
+                  .put(RequestFields.ACTIVE_USER,
+                      GetActiveUser.getActiveUserFromRequest(request, context));
 
               String action = (String) jsonMap.get("action");
 

--- a/backEnd/src/main/java/utilities/GetActiveUser.java
+++ b/backEnd/src/main/java/utilities/GetActiveUser.java
@@ -1,5 +1,6 @@
 package utilities;
 
+import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.auth0.jwk.Jwk;
 import com.auth0.jwk.JwkException;
@@ -8,17 +9,33 @@ import com.auth0.jwk.UrlJwkProvider;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.google.common.collect.ImmutableList;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.interfaces.RSAPublicKey;
+import java.util.List;
 import java.util.Map;
 
 public class GetActiveUser {
 
   public static final String PUBLIC_RSA_KEY_URL = "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ebbPP76nO/.well-known/jwks.json";
+  public static final List LIVE_FUNCTIONS = ImmutableList
+      .of("UsersPostEndpoint", "GroupsPostEndpoint", "CategoriesPostEndpoint");
+  public static final String EMULATED_ACTIVE_USER_KEY = "EMULATED_ACTIVE_USER";
 
-  public static String getActiveUserFromRequest(APIGatewayProxyRequestEvent request)
+  public static String getActiveUserFromRequest(APIGatewayProxyRequestEvent request,
+      Context context)
       throws JwkException, MalformedURLException {
+    String functionName = context.getFunctionName();
+
+    if (!LIVE_FUNCTIONS.contains(functionName)) {
+      String emulatedActiveUser = System.getenv(EMULATED_ACTIVE_USER_KEY);
+
+      if (emulatedActiveUser != null) {
+        return emulatedActiveUser;
+      }
+    }
+
     Map<String, String> headers = request.getHeaders();
     String authorization = headers.get("Authorization");
 


### PR DESCRIPTION
## Summary
This one is fairly straight forward. I pretty much changed the getting of the active user such that if the function isn't one of our live functions and if the environment variable is set, then we don't need to have valid id_tokens set in the header when testing from the API Gateway console.

## Testing
I uploaded the code to my testing lambda and the categories post handler lambda and made sure the call still failed to the categories post handler when tokens weren't set but the environment variable was, and I made sure that the call to my testing lambda gave correct results when I set the emulated environment var on my testing lambda.