### PR TITLE
Fixed event creation to account for single digit hours

### DIFF
--- a/frontEnd/lib/events_widgets/event_create.dart
+++ b/frontEnd/lib/events_widgets/event_create.dart
@@ -70,6 +70,9 @@ class _CreateEventState extends State<CreateEvent> {
     eventStartTime = (currentTime.hour + 1).toString() + ":00";
     if ((currentTime.hour + 1) < 10) {
       eventStartTime = "0" + eventStartTime;
+    } else if((currentTime.hour + 1) > 23) {
+      eventStartTime = "00:00";
+      eventStartDate = convertDateToString(DateTime.now().add(Duration(days: 1)));
     }
     pollDurationController.text =
         Globals.currentGroup.defaultPollDuration.toString();


### PR DESCRIPTION
## Summary
Added a check for the case where the hour is a single digit. If it is, then a zero is added in front of that digit so that the format for the time stays HH:MM.

## Testing
I created a couple of events with a start time where the hour was a single digit and made the sure the event was created successfully and displayed correctly in both the app and the database.