### PR TITLE
Cleaned up the UI for uploading/editing group icon

### DIFF
--- a/frontEnd/lib/groups_widgets/groups_create.dart
+++ b/frontEnd/lib/groups_widgets/groups_create.dart
@@ -92,7 +92,7 @@ class _CreateGroupState extends State<CreateGroup> {
                     alignment: Alignment.topRight,
                     decoration: BoxDecoration(
                         image: DecorationImage(
-                            fit: BoxFit.fitHeight,
+                            fit: BoxFit.cover,
                             image: this.icon == null
                                 ? getIconUrl(null)
                                 : FileImage(this.icon))),

--- a/frontEnd/lib/groups_widgets/groups_settings.dart
+++ b/frontEnd/lib/groups_widgets/groups_settings.dart
@@ -146,7 +146,7 @@ class _GroupSettingsState extends State<GroupSettings> {
                           alignment: Alignment.topRight,
                           decoration: BoxDecoration(
                               image: DecorationImage(
-                                  fit: BoxFit.fitHeight,
+                                  fit: BoxFit.cover,
                                   image: this.icon == null
                                       ? getIconUrl(currentGroupIcon)
                                       : FileImage(this.icon))),

--- a/frontEnd/lib/user_settings.dart
+++ b/frontEnd/lib/user_settings.dart
@@ -112,7 +112,7 @@ class _UserSettingsState extends State<UserSettings> {
                           alignment: Alignment.topRight,
                           decoration: BoxDecoration(
                               image: DecorationImage(
-                                  fit: BoxFit.fitHeight,
+                                  fit: BoxFit.cover,
                                   image: _icon == null
                                       ? getUserIconUrl(Globals.user)
                                       : FileImage(_icon))),


### PR DESCRIPTION
I changed the UI to match that of the user settings for uploading and editing a group icon.

Note that right now there is still a bug of changes to icons not persisting if you don't reload the group in the groups_home. After talking with john, this can be easily solved by returning a group from the editGroup function.