### PR TITLE
Member popup re-design

### DIFF
--- a/frontEnd/lib/groups_widgets/group_row.dart
+++ b/frontEnd/lib/groups_widgets/group_row.dart
@@ -18,21 +18,28 @@ class GroupRow extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: <Widget>[
-              IconButton(
-                  iconSize: MediaQuery.of(context).size.width * .20,
-                  icon: Image(
-                    image: getIconUrl(group.icon),
-                  ),
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) => GroupPage(
-                                groupId: group.groupId,
-                                groupName: group.groupName,
-                              )),
-                    ).then((_) => GroupsHome());
-                  }),
+              GestureDetector(
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => GroupPage(
+                              groupId: group.groupId,
+                              groupName: group.groupName,
+                            )),
+                  ).then((_) => GroupsHome());
+                },
+                child: Container(
+                  height: MediaQuery.of(context).size.width * .20,
+                  width: MediaQuery.of(context).size.width * .20,
+                  decoration: BoxDecoration(
+                      image: DecorationImage(
+                          image: getIconUrl(group.icon), fit: BoxFit.cover)),
+                ),
+              ),
+              Padding(
+                  padding: EdgeInsets.all(
+                      MediaQuery.of(context).size.height * .002)),
               Expanded(
                 child: GestureDetector(
                   onTap: () {

--- a/frontEnd/lib/widgets/user_row.dart
+++ b/frontEnd/lib/widgets/user_row.dart
@@ -22,10 +22,17 @@ class UserRow extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.all(2.0),
-            child: Image(image: getIconUrl(icon), fit: BoxFit.fitHeight),
+          Container(
+            // TODO allow user to click on image to get blown up pic
+            height: MediaQuery.of(context).size.height * .2,
+            width: MediaQuery.of(context).size.width * .15,
+            decoration: BoxDecoration(
+                image: DecorationImage(
+                    image: getIconUrl(icon), fit: BoxFit.cover)),
           ),
+          Padding(
+              padding:
+                  EdgeInsets.all(MediaQuery.of(context).size.height * .005)),
           Expanded(
             child: Text(
               "${this.displayName} (@${this.username})",


### PR DESCRIPTION
### Overview

Previously it was a little cumbersome to have to type in the usernames/displaynames of your favorites in order for them to show up. Furthermore, it made the popup feel almost glitchy since it's not self evident that typing will start to show suggestions.

This redesign adds an icon next to the text input of adding a non-favorite. When clicked, it displays all the favorites of the user that are currently not in the group. So now you can see them all without having to remember who you are favorites with.

I also made the icons in the user rows fit to the same size as well as the group icons in the group rows.

### Testing
I added and removed users from a group in different orderings to make sure that everything was displaying correctly (such as add a member from favorites, close, open the popup and ensure that it's showing correctly and not showing in the favorites section).