### PR TITLE
Automatic refreshes

### DIFF
--- a/frontEnd/lib/groups_widgets/group_page.dart
+++ b/frontEnd/lib/groups_widgets/group_page.dart
@@ -86,7 +86,10 @@ class _GroupPageState extends State<GroupPage> {
           onPressed: () {
             Navigator.push(context,
                     MaterialPageRoute(builder: (context) => CreateEvent()))
-                .then((_) => GroupPage());
+                .then((_) {
+              // TODO figure out a better way to refresh without making unnecessary API calls
+              this.refreshList();
+            });
           },
         ),
       );

--- a/frontEnd/lib/groups_widgets/group_row.dart
+++ b/frontEnd/lib/groups_widgets/group_row.dart
@@ -6,8 +6,9 @@ import 'package:frontEnd/utilities/utilities.dart';
 
 class GroupRow extends StatelessWidget {
   final Group group;
+  final Function refreshGroups;
 
-  GroupRow(this.group);
+  GroupRow(this.group, {this.refreshGroups});
 
   @override
   Widget build(BuildContext context) {
@@ -27,7 +28,10 @@ class GroupRow extends StatelessWidget {
                               groupId: group.groupId,
                               groupName: group.groupName,
                             )),
-                  ).then((_) => GroupsHome());
+                  ).then((val) {
+                    // TODO figure out a better way to refresh without making unnecessary API calls
+                    this.refreshGroups();
+                  });
                 },
                 child: Container(
                   height: MediaQuery.of(context).size.width * .20,
@@ -50,7 +54,10 @@ class GroupRow extends StatelessWidget {
                                 groupId: group.groupId,
                                 groupName: group.groupName,
                               )),
-                    ).then((_) => GroupsHome());
+                    ).then((val) {
+                      // TODO figure out a better way to refresh without making unnecessary API calls
+                      this.refreshGroups();
+                    });
                   },
                   child: Container(
                     color: Colors.blueGrey.withOpacity(0.25),

--- a/frontEnd/lib/groups_widgets/groups_create.dart
+++ b/frontEnd/lib/groups_widgets/groups_create.dart
@@ -228,11 +228,7 @@ class _CreateGroupState extends State<CreateGroup> {
           .pop('dialog'); // dismiss the loading dialog
 
       if (success) {
-        Navigator.pushAndRemoveUntil(
-            context,
-            new MaterialPageRoute(
-                builder: (BuildContext context) => GroupsHome()),
-            (Route<dynamic> route) => false);
+        Navigator.of(context).pop();
       }
     } else {
       setState(() => autoValidate = true);

--- a/frontEnd/lib/groups_widgets/groups_home.dart
+++ b/frontEnd/lib/groups_widgets/groups_home.dart
@@ -58,7 +58,6 @@ class _GroupsHomeState extends State<GroupsHome> {
       }
     });
 
-
     Future<String> token = this.firebaseMessaging.getToken();
     UsersManager.registerPushEndpoint(token, context);
 
@@ -205,8 +204,10 @@ class _GroupsHomeState extends State<GroupsHome> {
                   child: RefreshIndicator(
                       onRefresh: refreshList,
                       child: GroupsList(
-                          groups: (searching) ? searchGroups : totalGroups,
-                          searching: searching))),
+                        groups: (searching) ? searchGroups : totalGroups,
+                        searching: searching,
+                        refreshGroups: refreshList,
+                      ))),
             ),
             Padding(
               // used to make sure the group list doesn't go too far down, expanded widget stops when reaching this
@@ -225,7 +226,10 @@ class _GroupsHomeState extends State<GroupsHome> {
             Navigator.push(
               context,
               MaterialPageRoute(builder: (context) => CreateGroup()),
-            ).then((_) => GroupsHome());
+            ).then((val) {
+              // TODO figure out a better way to refresh without making unnecessary API calls
+              refreshList();
+            });
           },
         ),
       ),

--- a/frontEnd/lib/groups_widgets/groups_list.dart
+++ b/frontEnd/lib/groups_widgets/groups_list.dart
@@ -5,8 +5,10 @@ import 'group_row.dart';
 class GroupsList extends StatefulWidget {
   final List<Group> groups;
   final bool searching;
+  final Function refreshGroups;
 
-  GroupsList({Key key, this.groups, this.searching}) : super(key: key);
+  GroupsList({Key key, this.groups, this.searching, this.refreshGroups})
+      : super(key: key);
 
   @override
   _GroupsListState createState() => _GroupsListState();
@@ -34,7 +36,10 @@ class _GroupsListState extends State<GroupsList> {
           shrinkWrap: true,
           itemCount: widget.groups.length,
           itemBuilder: (context, index) {
-            return GroupRow(widget.groups[index]);
+            return GroupRow(
+              widget.groups[index],
+              refreshGroups: widget.refreshGroups,
+            );
           },
         ),
       );


### PR DESCRIPTION
## Overview
I implemented code to automatically refresh certain pages when specific pages are popped. For example, after creating a group and that page is popped the groups_home page is refreshed to automatically show this new group. This is also done whenever an event is created as well.

In the future we need to look into having this functionality without making these useless API calls. Likely having the backend return objects in the success response is the solution.

## Testing
I created some groups and events and watched as the pages would automatically refresh.