### PR TITLE
Event creation/details refactoring on front end

### DIFF
--- a/frontEnd/lib/events_widgets/event_create.dart
+++ b/frontEnd/lib/events_widgets/event_create.dart
@@ -179,7 +179,7 @@ class _CreateEventState extends State<CreateEvent> {
                               if (willRsvp == false) {
                                 rsvpDurationController.text = "0";
                                 rsvpDuration = rsvpDurationController.text;
-                                skipButtonText = "Enable RSVP";
+                                skipButtonText = "Set RSVP";
                                 rsvpLabelText = "Skipping RSVP phase";
                               } else {
                                 rsvpDurationController.text = Globals

--- a/frontEnd/lib/events_widgets/event_details_closed.dart
+++ b/frontEnd/lib/events_widgets/event_details_closed.dart
@@ -118,20 +118,17 @@ class _EventDetailsClosedState extends State<EventDetailsClosed> {
                             fontSize:
                                 DefaultTextStyle.of(context).style.fontSize *
                                     0.3)),
-                    Visibility(
-                      visible: event.optedIn.length > 0,
-                      child:  ExpansionTile(
-                        title: Text("Attendees (${event.optedIn.length})"),
-                        children: <Widget>[
-                          SizedBox(
-                            height: MediaQuery.of(context).size.height * .2,
-                            child: ListView(
-                              shrinkWrap: true,
-                              children: userRows,
-                            ),
+                    ExpansionTile(
+                      title: Text("Attendees (${event.optedIn.length})"),
+                      children: <Widget>[
+                        SizedBox(
+                          height: MediaQuery.of(context).size.height * .2,
+                          child: ListView(
+                            shrinkWrap: true,
+                            children: userRows,
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                   ],
                 ),

--- a/frontEnd/lib/events_widgets/event_details_occurring.dart
+++ b/frontEnd/lib/events_widgets/event_details_occurring.dart
@@ -122,20 +122,17 @@ class _EventDetailsOccurringState extends State<EventDetailsOccurring> {
                             fontSize:
                                 DefaultTextStyle.of(context).style.fontSize *
                                     0.3)),
-                    Visibility(
-                      visible: event.optedIn.length > 0,
-                      child:  ExpansionTile(
-                        title: Text("Attendees (${event.optedIn.length})"),
-                        children: <Widget>[
-                          SizedBox(
-                            height: MediaQuery.of(context).size.height * .2,
-                            child: ListView(
-                              shrinkWrap: true,
-                              children: userRows,
-                            ),
+                    ExpansionTile(
+                      title: Text("Attendees (${event.optedIn.length})"),
+                      children: <Widget>[
+                        SizedBox(
+                          height: MediaQuery.of(context).size.height * .2,
+                          child: ListView(
+                            shrinkWrap: true,
+                            children: userRows,
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                   ],
                 ),

--- a/frontEnd/lib/events_widgets/event_details_voting.dart
+++ b/frontEnd/lib/events_widgets/event_details_voting.dart
@@ -128,20 +128,17 @@ class _EventDetailsVotingState extends State<EventDetailsVoting> {
                             fontSize:
                                 DefaultTextStyle.of(context).style.fontSize *
                                     0.3)),
-                    Visibility(
-                      visible: event.optedIn.length > 0,
-                      child:  ExpansionTile(
-                        title: Text("Attendees (${event.optedIn.length})"),
-                        children: <Widget>[
-                          SizedBox(
-                            height: MediaQuery.of(context).size.height * .2,
-                            child: ListView(
-                              shrinkWrap: true,
-                              children: userRows,
-                            ),
+                    ExpansionTile(
+                      title: Text("Attendees (${event.optedIn.length})"),
+                      children: <Widget>[
+                        SizedBox(
+                          height: MediaQuery.of(context).size.height * .2,
+                          child: ListView(
+                            shrinkWrap: true,
+                            children: userRows,
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                     Padding(
                       padding: EdgeInsets.all(


### PR DESCRIPTION
## Summary
So since a lot of the event issues are relatively small changes, I'm putting a bunch of them in this request. Specifically:

- #337 
- #334 
- #331 
- #330 
- #329

I also changed the format for the displayed dates/times on the event creation page to be consistent with the rest of the app. (So the date shows as mm/dd/yyyy, time is hh:mm AM/PM) Note the API requests still use the same formats as before, I only changed the ones displayed on the page.

For #334 I opted to only hide the attendees dropdown from the details pages for non-RSVP phases. I personally think having the empty dropdown is fine during RSVP since it can still be edited, and I think seeing a user pop in and out of the dropdown looks better than trying to make the whole dropdown disappear/reappear.

## Testing
I made a bunch of events, tested valid/invalid cases for the new validation for RSVP duration and voting duration. Also made some events using the new "Skip RSVP" button. I opted out of some events and made sure the dropdown didn't appear in any phases after RSVP. I checked the event cards and details pages during the "occurring" phase to make sure that the text would change depending on whether the event has started or not.