### PR TITLE
Fixed event create page not fully accounting for default duration of zero

### DIFF
--- a/frontEnd/lib/events_widgets/event_create.dart
+++ b/frontEnd/lib/events_widgets/event_create.dart
@@ -84,8 +84,18 @@ class _CreateEventState extends State<CreateEvent> {
         Globals.currentGroup.defaultConsiderDuration.toString();
     considerDuration = considerDurationController.text;
     votingDuration = votingDurationController.text;
-    considerButtonText = "Skip Consider";
-    voteButtonText = "Skip Voting";
+    if (considerDuration == "0") {
+      considerButtonText = "Set Consider";
+      willConsider = false;
+    } else {
+      considerButtonText = "Skip Consider";
+    }
+    if (votingDuration == "0") {
+      voteButtonText = "Set Voting";
+      willVote = false;
+    } else {
+      voteButtonText = "Skip Voting";
+    }
     super.initState();
   }
 


### PR DESCRIPTION
Added some logic in the init to check each default duration and see if they're equal to zero. To test this, I created a new group with both default consider duration and default voting duration set to zero.