### PR TITLE
Fixed bug that stops users from being added to a group after group creation

### DIFF
--- a/backEnd/src/main/java/imports/GroupsManager.java
+++ b/backEnd/src/main/java/imports/GroupsManager.java
@@ -774,7 +774,7 @@ public class GroupsManager extends DatabaseAccessManager {
     UpdateItemSpec updateItemSpec;
 
     //update users with new group mapping based on which attributes were updated
-    if (persistingUsernames.size() > 0) {
+    if (oldGroup != null && persistingUsernames.size() > 0) {
       //since this group already exists, we're just updating the mappings that have changed for existing users
       //for simplicity in the code, we'll always update the group name
       updateExpression =


### PR DESCRIPTION
## Summary
The only consideration for if a user was being added was whether or not the group was new. This means that new users added during a group edit were not able to be added. I fixed this by determining which users were new and which users were persisting (already members of the group). I then handle each situation separately.

## Testing
I deployed to the john api and then I added a user at group create. Then I removed and re-added the user from the edit page. I checked the dynamodb values all through out this to make sure that the data was accurate. 

## Coverage
Groups Manager continues to lack the testing that allows bugs like this into the code base. We will get that coverage eventually but today is not that day.