### PR TITLE
Hide dropdown from event details if nobody is being considered

### DIFF
--- a/frontEnd/lib/events_widgets/event_details_closed.dart
+++ b/frontEnd/lib/events_widgets/event_details_closed.dart
@@ -133,7 +133,7 @@ class _EventDetailsClosedState extends State<EventDetailsClosed> {
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: TextStyle(fontSize: 16)),
-                      Visibility (
+                      Visibility(
                         visible: this.event.optedIn.length > 0,
                         child: ExpansionTile(
                           title: Text("Considered (${this.event.optedIn.length})"),
@@ -151,6 +151,15 @@ class _EventDetailsClosedState extends State<EventDetailsClosed> {
                             ),
                           ],
                         ),
+                      ),
+                      Visibility(
+                        visible: this.event.optedIn.length <= 0,
+                        child: AutoSizeText("No members considered",
+                          minFontSize: 12,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(fontSize: 16),
+                        )
                       ),
                     ],
                   ),

--- a/frontEnd/lib/events_widgets/event_details_consider.dart
+++ b/frontEnd/lib/events_widgets/event_details_consider.dart
@@ -154,6 +154,15 @@ class _EventDetailsConsiderState extends State<EventDetailsConsider> {
                         ],
                       ),
                     ),
+                    Visibility(
+                        visible: this.event.optedIn.length <= 0,
+                        child: AutoSizeText("No members currently being considered",
+                          minFontSize: 12,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(fontSize: 16),
+                        )
+                    ),
                     Padding(
                       padding: EdgeInsets.all(
                           MediaQuery.of(context).size.height * .01),

--- a/frontEnd/lib/events_widgets/event_details_occurring.dart
+++ b/frontEnd/lib/events_widgets/event_details_occurring.dart
@@ -135,7 +135,7 @@ class _EventDetailsOccurringState extends State<EventDetailsOccurring> {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(fontSize: 16)),
-                    Visibility (
+                    Visibility(
                       visible: this.event.optedIn.length > 0,
                       child: ExpansionTile(
                         title: Text("Considered (${this.event.optedIn.length})"),
@@ -153,6 +153,15 @@ class _EventDetailsOccurringState extends State<EventDetailsOccurring> {
                           ),
                         ],
                       ),
+                    ),
+                    Visibility(
+                        visible: this.event.optedIn.length <= 0,
+                        child: AutoSizeText("No members considered",
+                          minFontSize: 12,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(fontSize: 16),
+                        )
                     ),
                   ],
                 ),

--- a/frontEnd/lib/events_widgets/event_details_voting.dart
+++ b/frontEnd/lib/events_widgets/event_details_voting.dart
@@ -141,7 +141,7 @@ class _EventDetailsVotingState extends State<EventDetailsVoting> {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(fontSize: 16)),
-                    Visibility (
+                    Visibility(
                       visible: this.event.optedIn.length > 0,
                       child: ExpansionTile(
                         title: Text("Considered (${this.event.optedIn.length})"),
@@ -159,6 +159,15 @@ class _EventDetailsVotingState extends State<EventDetailsVoting> {
                           ),
                         ],
                       ),
+                    ),
+                    Visibility(
+                        visible: this.event.optedIn.length <= 0,
+                        child: AutoSizeText("No members considered",
+                          minFontSize: 12,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(fontSize: 16),
+                        )
                     ),
                     Padding(
                       padding: EdgeInsets.all(


### PR DESCRIPTION
Small change, hopefully it's exactly what you'd expect especially considering we talked about it in slack already.

For testing I just made some events where I was the only group member and then opted out of consideration. I checked each phase to make sure that the dropdown was gone.

Closes #334 