### PR TITLE
Added EventsBatch to groupEdit and fixed bug in newEvent for event creator

### DIFF
--- a/backEnd/src/main/java/imports/GroupsManager.java
+++ b/backEnd/src/main/java/imports/GroupsManager.java
@@ -1039,11 +1039,13 @@ public class GroupsManager extends DatabaseAccessManager {
                 "set " + UsersManager.GROUPS + ".#groupId." + LAST_ACTIVITY + " = :lastActivity";
             final ValueMap valueMapEventCreator = new ValueMap()
                 .withString(":lastActivity", newGroup.getLastActivity());
+            final NameMap nameMapEventCreator = new NameMap()
+                .with("#groupId", newGroup.getGroupId());
             final UpdateItemSpec updateItemSpecEventCreator = new UpdateItemSpec()
                 .withPrimaryKey(DatabaseManagers.USERS_MANAGER.getPrimaryKeyIndex(), oldMember)
                 .withUpdateExpression(updateExpressionEventCreator)
                 .withValueMap(valueMapEventCreator)
-                .withNameMap(nameMap);
+                .withNameMap(nameMapEventCreator);
 
             DatabaseManagers.USERS_MANAGER.updateItem(updateItemSpecEventCreator);
           } catch (final Exception e) {


### PR DESCRIPTION
## Summary
I added event batch handling to group edit. This was very straight forward and copy pasta from getGroup implementation.

I removed the extra db call and group return from opt in/out since the return isn't being used on the front end.

I fixed a dumb bug I introduced the other day.

## Testing
I deployed my code to my GroupsJohn api endpoint.
I created events and made sure the group popped to the top of my list.
I edited a group and made sure I stayed on the same events batch.