### PR TITLE
catching exception that is out of our control for sns

### DIFF
--- a/backEnd/src/main/java/imports/SnsAccessManager.java
+++ b/backEnd/src/main/java/imports/SnsAccessManager.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.sns.model.CreatePlatformEndpointRequest;
 import com.amazonaws.services.sns.model.CreatePlatformEndpointResult;
 import com.amazonaws.services.sns.model.DeleteEndpointRequest;
 import com.amazonaws.services.sns.model.DeleteEndpointResult;
+import com.amazonaws.services.sns.model.EndpointDisabledException;
 import com.amazonaws.services.sns.model.GetEndpointAttributesRequest;
 import com.amazonaws.services.sns.model.GetEndpointAttributesResult;
 import com.amazonaws.services.sns.model.GetPlatformApplicationAttributesRequest;
@@ -137,7 +138,17 @@ public class SnsAccessManager {
         .withTargetArn(arn)
         .withMessage(jsonNotification);
     publishRequest.setMessageStructure("json");
-    return this.client.publish(publishRequest);
+
+    PublishResult publishResult;
+    try {
+      publishResult = this.client.publish(publishRequest);
+    } catch (final EndpointDisabledException ede) {
+      //this isn't an error on our end, read more about this exception here:
+      //https://forums.aws.amazon.com/thread.jspa?threadID=174551
+      publishResult = new PublishResult();
+    }
+
+    return  publishResult;
   }
 
   public GetPlatformApplicationAttributesResult getPlatformAttributes(final String platformArn) {


### PR DESCRIPTION
## Summary
I believe this exception happened because I uninstalled the app from my emulator, but I have accounts that got left with bad sns push arns. This let them to get disabled and a EndpointDisabledException was thrown. This is out of our control so I catch this exception now.