### PR TITLE
Fixing bug where finalized event is left in the pending events table.

### DIFF
--- a/backEnd/src/main/java/imports/PendingEventsManager.java
+++ b/backEnd/src/main/java/imports/PendingEventsManager.java
@@ -131,9 +131,6 @@ public class PendingEventsManager extends DatabaseAccessManager {
           } else {
             //we need to set the selected choice as the one with the highest percent
             updatedEvent.setSelectedChoice(this.getSelectedChoice(event, metrics));
-
-            DatabaseManagers.GROUPS_MANAGER
-                .updateEvent(group, eventId, updatedEvent, false, metrics);
           }
 
           //update the event with whatever got added to it

--- a/backEnd/src/main/java/imports/UsersManager.java
+++ b/backEnd/src/main/java/imports/UsersManager.java
@@ -117,7 +117,11 @@ public class UsersManager extends DatabaseAccessManager {
     if (jsonMap.containsKey(UsersManager.USERNAME)) {
       final String otherUser = (String) jsonMap.get(UsersManager.USERNAME);
       Item user = this.getItemByPrimaryKey(otherUser);
-      resultStatus = new ResultStatus(true, JsonEncoders.convertObjectToJson(user.asMap()));
+      if (user != null) {
+        resultStatus = new ResultStatus(true, JsonEncoders.convertObjectToJson(user.asMap()));
+      } else {
+        resultStatus = new ResultStatus(true, "User not found.");
+      }
     } else if (jsonMap.containsKey(RequestFields.ACTIVE_USER)) {
       try {
         final String activeUser = (String) jsonMap.get(RequestFields.ACTIVE_USER);


### PR DESCRIPTION
## Summary
There was a bug in the skip voting implementation that was leaving finalized events in the pending events table.