### PR TITLE
Removal of wasteful API call on event create

### DIFF
--- a/front_end_pocket_poll/lib/events_widgets/event_create.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_create.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:front_end_pocket_poll/imports/result_status.dart';
+import 'package:front_end_pocket_poll/models/group.dart';
 import 'package:front_end_pocket_poll/utilities/utilities.dart';
 import 'package:front_end_pocket_poll/utilities/validator.dart';
 
@@ -705,12 +706,13 @@ class _CreateEventState extends State<CreateEvent> {
             considerDuration: int.parse(this.considerDuration));
 
         showLoadingDialog(context, "Creating event...", true);
-        ResultStatus result =
+        ResultStatus<Group> result =
             await GroupsManager.newEvent(Globals.currentGroup.groupId, event);
         Navigator.of(this.context, rootNavigator: true).pop('dialog');
 
         if (result.success) {
-          Navigator.of(this.context).pop();
+          Globals.currentGroup = result.data;
+          Navigator.of(this.context).pop("Event Created");
         } else {
           showErrorMessage("Error", result.errorMessage, this.context);
         }

--- a/front_end_pocket_poll/lib/groups_widgets/group_page.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_page.dart
@@ -148,8 +148,14 @@ class _GroupPageState extends State<GroupPage> {
           onPressed: () {
             Navigator.push(context,
                     MaterialPageRoute(builder: (context) => CreateEvent()))
-                .then((_) {
-              this.refreshList();
+                .then((val) {
+              if (val != null) {
+                // this means that an event was created, so don't make an API call to refresh
+                updatePage();
+              } else {
+                // no event created, so make API call to make sure page is most up to date
+                refreshList();
+              }
             });
           },
         ),

--- a/front_end_pocket_poll/lib/imports/groups_manager.dart
+++ b/front_end_pocket_poll/lib/imports/groups_manager.dart
@@ -214,8 +214,9 @@ class GroupsManager {
     return retVal;
   }
 
-  static Future<ResultStatus> newEvent(String groupId, Event event) async {
-    ResultStatus retVal = new ResultStatus(success: false);
+  static Future<ResultStatus<Group>> newEvent(
+      String groupId, Event event) async {
+    ResultStatus<Group> retVal = new ResultStatus(success: false);
 
     Map<String, dynamic> jsonRequestBody = getEmptyApiRequest();
     jsonRequestBody[RequestFields.ACTION] = newEventAction;
@@ -233,6 +234,8 @@ class GroupsManager {
         Map<String, dynamic> body = jsonDecode(response.data);
         ResponseItem responseItem = new ResponseItem.fromJson(body);
         if (responseItem.success) {
+          retVal.data =
+              new Group.fromJson(json.decode(responseItem.resultMessage));
           retVal.success = true;
         } else {
           retVal.errorMessage = "Unable to create event.";


### PR DESCRIPTION
## Overview
Event create call on frontend now utilizes the returned group from the backend. The group page will only make an API call to refresh if no event was created.

## Testing
Ran the behavioral tests and also created events and made sure that new ones made by others showed up after I created the one I was making.