### PR TITLE
First version of database maintenance.

### DIFF
--- a/backEnd/pom.xml
+++ b/backEnd/pom.xml
@@ -114,14 +114,6 @@
 
     <!-- Build settings -->
     <build>
-<!--        <resources>-->
-<!--            <resource>-->
-<!--                <directory>src/main/java/DbMaintenance</directory>-->
-<!--                <excludes>-->
-<!--                    <exclude>**/*</exclude>-->
-<!--                </excludes>-->
-<!--            </resource>-->
-<!--        </resources>-->
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -156,7 +148,7 @@
                     <source>8</source>
                     <target>8</target>
                     <excludes>
-                        <exclude>src/main/java/DbMaintenance/**</exclude>
+                        <exclude>src/main/java/dbMaintenance/**</exclude>
                     </excludes>
                     <annotationProcessorPaths>
                         <path>

--- a/backEnd/pom.xml
+++ b/backEnd/pom.xml
@@ -114,6 +114,14 @@
 
     <!-- Build settings -->
     <build>
+<!--        <resources>-->
+<!--            <resource>-->
+<!--                <directory>src/main/java/DbMaintenance</directory>-->
+<!--                <excludes>-->
+<!--                    <exclude>**/*</exclude>-->
+<!--                </excludes>-->
+<!--            </resource>-->
+<!--        </resources>-->
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -147,6 +155,9 @@
                 <configuration>
                     <source>8</source>
                     <target>8</target>
+                    <excludes>
+                        <exclude>src/main/java/DbMaintenance/**</exclude>
+                    </excludes>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/backEnd/src/main/java/DbMaintenance/Managers/MaintenanceDbAccessManager.java
+++ b/backEnd/src/main/java/DbMaintenance/Managers/MaintenanceDbAccessManager.java
@@ -1,0 +1,16 @@
+package DbMaintenance.Managers;
+
+import com.amazonaws.services.dynamodbv2.document.Item;
+import java.util.Iterator;
+import managers.DbAccessManager;
+
+public class MaintenanceDbAccessManager extends DbAccessManager {
+
+  public MaintenanceDbAccessManager() {
+    super();
+  }
+
+  public Iterator<Item> scanUsersTable() {
+    return this.usersTable.scan().iterator();
+  }
+}

--- a/backEnd/src/main/java/DbMaintenance/Managers/MaintenanceDbAccessManager.java
+++ b/backEnd/src/main/java/DbMaintenance/Managers/MaintenanceDbAccessManager.java
@@ -1,4 +1,4 @@
-package DbMaintenance.Managers;
+package dbMaintenance.managers;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
 import java.util.Iterator;

--- a/backEnd/src/main/java/DbMaintenance/controllers/DbMaintenanceController.java
+++ b/backEnd/src/main/java/DbMaintenance/controllers/DbMaintenanceController.java
@@ -1,4 +1,4 @@
-package DbMaintenance.controllers;
+package dbMaintenance.controllers;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
@@ -7,30 +7,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import controllers.ApiRequestController;
-import controllers.CreateNewGroupController;
-import controllers.DeleteCategoryController;
-import controllers.DeleteGroupController;
-import controllers.EditCategoryController;
-import controllers.EditGroupController;
-import controllers.GetBatchOfEventsController;
-import controllers.GetCategoriesController;
-import controllers.GetGroupController;
-import controllers.GetUserDataController;
-import controllers.LeaveGroupController;
-import controllers.MarkAllEventsSeenController;
-import controllers.MarkEventAsSeenController;
-import controllers.NewCategoryController;
-import controllers.NewEventController;
-import controllers.OptUserInOutController;
-import controllers.RegisterPushEndpointController;
-import controllers.RejoinGroupController;
-import controllers.SetUserGroupMuteController;
-import controllers.UnregisterPushEndpointController;
-import controllers.UpdateSortSettingController;
-import controllers.UpdateUserChoiceRatingsController;
-import controllers.UpdateUserSettingsController;
-import controllers.VoteForChoiceController;
-import controllers.WarmingController;
 import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,7 +27,7 @@ public class DbMaintenanceController implements
 
   public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent request,
       Context context) {
-    final String classMethod = "ProxyPostHandler.handleRequest";
+    final String classMethod = "DbMaintenanceController.handleRequest";
 
     final Metrics metrics = new Metrics(context.getAwsRequestId(), context.getLogger());
     metrics.commonSetup(classMethod);

--- a/backEnd/src/main/java/DbMaintenance/controllers/DbMaintenanceController.java
+++ b/backEnd/src/main/java/DbMaintenance/controllers/DbMaintenanceController.java
@@ -1,0 +1,119 @@
+package DbMaintenance.controllers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import controllers.ApiRequestController;
+import controllers.CreateNewGroupController;
+import controllers.DeleteCategoryController;
+import controllers.DeleteGroupController;
+import controllers.EditCategoryController;
+import controllers.EditGroupController;
+import controllers.GetBatchOfEventsController;
+import controllers.GetCategoriesController;
+import controllers.GetGroupController;
+import controllers.GetUserDataController;
+import controllers.LeaveGroupController;
+import controllers.MarkAllEventsSeenController;
+import controllers.MarkEventAsSeenController;
+import controllers.NewCategoryController;
+import controllers.NewEventController;
+import controllers.OptUserInOutController;
+import controllers.RegisterPushEndpointController;
+import controllers.RejoinGroupController;
+import controllers.SetUserGroupMuteController;
+import controllers.UnregisterPushEndpointController;
+import controllers.UpdateSortSettingController;
+import controllers.UpdateUserChoiceRatingsController;
+import controllers.UpdateUserSettingsController;
+import controllers.VoteForChoiceController;
+import controllers.WarmingController;
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+import utilities.ErrorDescriptor;
+import utilities.GetActiveUser;
+import utilities.JsonUtils;
+import utilities.Metrics;
+import utilities.RequestFields;
+import utilities.ResultStatus;
+import utilities.WarningDescriptor;
+
+public class DbMaintenanceController implements
+    RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+  private static final Map<String, Class<? extends ApiRequestController>> ACTIONS_TO_CONTROLLERS = Maps
+      .newHashMap(ImmutableMap.<String, Class<? extends ApiRequestController>>builder()
+          .put("keyUserRatingsByVersion", KeyUserRatingsByVersionController.class)
+          .build());
+
+  public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent request,
+      Context context) {
+    final String classMethod = "ProxyPostHandler.handleRequest";
+
+    final Metrics metrics = new Metrics(context.getAwsRequestId(), context.getLogger());
+    metrics.commonSetup(classMethod);
+
+    ResultStatus resultStatus;
+
+    try {
+      String action = request.getPath(); // this should be of the form '/action'
+      String[] splitAction = action.split("/"); // remove the prefixed slash
+
+      if (splitAction.length == 2) {
+        action = splitAction[1]; // the action is after the '/'
+
+        if (ACTIONS_TO_CONTROLLERS.containsKey(action)) {
+          final Map<String, Object> jsonMap = JsonUtils.parseInput(request.getBody());
+          metrics.setRequestBody(jsonMap); // attach here for logging before handling action
+
+          if (!jsonMap.containsKey(RequestFields.ACTIVE_USER)) {
+            //get the active user from the authorization header and put it in the request payload
+            jsonMap.put(RequestFields.ACTIVE_USER,
+                GetActiveUser.getActiveUserFromRequest(request, context));
+
+            final Class<? extends ApiRequestController> actionHandlerClass = ACTIONS_TO_CONTROLLERS
+                .get(action);
+            final Constructor c = actionHandlerClass.getConstructor(); // get the default
+            final ApiRequestController apiRequestHandler = (ApiRequestController) c.newInstance();
+            resultStatus = apiRequestHandler.processApiRequest(jsonMap, metrics);
+          } else {
+            //bad request body, log warning
+            resultStatus = ResultStatus.failure("Error: Bad request body.");
+          }
+        } else {
+          metrics.log(new WarningDescriptor<>(
+              new HashMap<String, Object>() {{
+                put("path", request.getPath());
+                put("body", request.getBody());
+              }},
+              classMethod, "Unknown action."));
+          resultStatus = ResultStatus.failure("Error: Unknown action.");
+        }
+      } else {
+        metrics.log(new WarningDescriptor<>(
+            new HashMap<String, Object>() {{
+              put("path", request.getPath());
+              put("body", request.getBody());
+            }},
+            classMethod, "Bad request format."));
+        resultStatus = ResultStatus.failure("Error: Bad request format.");
+      }
+    } catch (final Exception e) {
+      metrics.log(new ErrorDescriptor<>(
+          new HashMap<String, Object>() {{
+            put("path", request.getPath());
+            put("body", request.getBody());
+          }},
+          classMethod, e));
+      resultStatus = ResultStatus.failure("Error: Exception occurred.");
+    }
+
+    metrics.commonClose(resultStatus.success);
+    metrics.logMetrics();
+
+    return new APIGatewayProxyResponseEvent().withBody(resultStatus.toString());
+  }
+}

--- a/backEnd/src/main/java/DbMaintenance/controllers/KeyUserRatingsByVersionController.java
+++ b/backEnd/src/main/java/DbMaintenance/controllers/KeyUserRatingsByVersionController.java
@@ -1,0 +1,35 @@
+package DbMaintenance.controllers;
+
+import DbMaintenance.handlers.KeyUserRatingsByVersionHandler;
+import DbMaintenance.modules.MaintenanceInjector;
+import controllers.ApiRequestController;
+import exceptions.MissingApiRequestKeyException;
+import java.util.Map;
+import javax.inject.Inject;
+import utilities.ErrorDescriptor;
+import utilities.Metrics;
+import utilities.ResultStatus;
+
+public class KeyUserRatingsByVersionController implements ApiRequestController {
+
+  @Inject
+  public KeyUserRatingsByVersionHandler keyUserRatingsByVersionHandler;
+
+  @Override
+  public ResultStatus processApiRequest(Map<String, Object> jsonMap, Metrics metrics)
+      throws MissingApiRequestKeyException {
+    final String classMethod = "KeyUserRatingsByVersionController.processApiRequest";
+
+    ResultStatus resultStatus;
+
+    try {
+      MaintenanceInjector.getInjector(metrics).inject(this);
+      resultStatus = this.keyUserRatingsByVersionHandler.handle();
+    } catch (final Exception e) {
+      metrics.logWithBody(new ErrorDescriptor<>(classMethod, e));
+      resultStatus = ResultStatus.failure("Exception in " + classMethod);
+    }
+
+    return resultStatus;
+  }
+}

--- a/backEnd/src/main/java/DbMaintenance/controllers/KeyUserRatingsByVersionController.java
+++ b/backEnd/src/main/java/DbMaintenance/controllers/KeyUserRatingsByVersionController.java
@@ -1,7 +1,7 @@
-package DbMaintenance.controllers;
+package dbMaintenance.controllers;
 
-import DbMaintenance.handlers.KeyUserRatingsByVersionHandler;
-import DbMaintenance.modules.MaintenanceInjector;
+import dbMaintenance.handlers.KeyUserRatingsByVersionHandler;
+import dbMaintenance.modules.MaintenanceInjector;
 import controllers.ApiRequestController;
 import exceptions.MissingApiRequestKeyException;
 import java.util.Map;

--- a/backEnd/src/main/java/DbMaintenance/handlers/KeyUserRatingsByVersionHandler.java
+++ b/backEnd/src/main/java/DbMaintenance/handlers/KeyUserRatingsByVersionHandler.java
@@ -1,0 +1,105 @@
+package DbMaintenance.handlers;
+
+import DbMaintenance.Managers.MaintenanceDbAccessManager;
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
+import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
+import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
+import com.google.common.collect.ImmutableMap;
+import handlers.ApiRequestHandler;
+import java.util.Iterator;
+import java.util.Map;
+import javax.inject.Inject;
+import models.Category;
+import models.User;
+import utilities.ErrorDescriptor;
+import utilities.Metrics;
+import utilities.ResultStatus;
+
+public class KeyUserRatingsByVersionHandler implements ApiRequestHandler {
+
+  private final MaintenanceDbAccessManager maintenanceDbAccessManager;
+  private final Metrics metrics;
+
+  @Inject
+  public KeyUserRatingsByVersionHandler(final MaintenanceDbAccessManager maintenanceDbAccessManager,
+      final Metrics metrics) {
+    this.maintenanceDbAccessManager = maintenanceDbAccessManager;
+    this.metrics = metrics;
+  }
+
+  public ResultStatus handle() {
+    final String classMethod = "KeyUserRatingsByVersionHandler.handle";
+    this.metrics.commonSetup(classMethod);
+
+    ResultStatus resultStatus = ResultStatus
+        .successful("User Ratings keyed by version successfully.");
+
+    try {
+      final Iterator<Item> tableItems = this.maintenanceDbAccessManager.scanUsersTable();
+
+      while (tableItems.hasNext()) {
+        final Item userItem = tableItems.next();
+
+        try {
+          final String username = userItem.getString(User.USERNAME);
+          final Map<String, Object> oldUserRatings = userItem.getMap(User.CATEGORY_RATINGS);
+
+          for (final String categoryId : oldUserRatings.keySet()) {
+            try {
+              final Item categoryItem = this.maintenanceDbAccessManager.getCategoryItem(categoryId);
+
+              if (categoryItem != null) {
+                //We are assuming the ratings are saved for the newest version. With this being the
+                // case, we simply get the newest version and map the current rating map one level
+                // below that.
+
+                final Category category = new Category(categoryItem);
+
+                final Map<String, Object> choiceToRatings = (Map<String, Object>) oldUserRatings
+                    .get(categoryId);
+
+                final Map versionToRatingsMap = ImmutableMap
+                    .of(category.getVersion(), choiceToRatings);
+
+                final String updateExpression =
+                    "Set " + User.CATEGORY_RATINGS + ".#categoryId = :versionMap";
+                final NameMap nameMap = new NameMap().with("#categoryId", categoryId);
+                final ValueMap valueMap = new ValueMap()
+                    .withMap(":versionMap", versionToRatingsMap);
+
+                final UpdateItemSpec updateItemSpec = new UpdateItemSpec()
+                    .withUpdateExpression(updateExpression)
+                    .withNameMap(nameMap)
+                    .withValueMap(valueMap);
+
+                this.maintenanceDbAccessManager.updateUser(username, updateItemSpec);
+              } else {
+                //The category couldn't be found. Assume it was deleted and delete the rating entry.
+                final String updateExpression = "remove " + User.CATEGORY_RATINGS + ".#categoryId";
+                final NameMap nameMap = new NameMap().with("#categoryId", categoryId);
+
+                final UpdateItemSpec updateItemSpec = new UpdateItemSpec()
+                    .withUpdateExpression(updateExpression)
+                    .withNameMap(nameMap);
+
+                this.maintenanceDbAccessManager.updateUser(username, updateItemSpec);
+              }
+            } catch (final Exception e) {
+              this.metrics.log(new ErrorDescriptor<>(username + " " + categoryId, classMethod, e));
+            }
+          }
+        } catch (final Exception e) {
+          this.metrics.log(new ErrorDescriptor<>(userItem.get(User.USERNAME), classMethod, e));
+          resultStatus = ResultStatus.failure("Exception in " + classMethod);
+        }
+      }
+    } catch (final Exception e) {
+      this.metrics.logWithBody(new ErrorDescriptor<>(classMethod, e));
+      resultStatus = ResultStatus.failure("Exception in " + classMethod);
+    }
+
+    this.metrics.commonClose(resultStatus.success);
+    return resultStatus;
+  }
+}

--- a/backEnd/src/main/java/DbMaintenance/modules/MaintenanceInjector.java
+++ b/backEnd/src/main/java/DbMaintenance/modules/MaintenanceInjector.java
@@ -1,4 +1,4 @@
-package DbMaintenance.modules;
+package dbMaintenance.modules;
 
 import utilities.Metrics;
 

--- a/backEnd/src/main/java/DbMaintenance/modules/MaintenanceInjector.java
+++ b/backEnd/src/main/java/DbMaintenance/modules/MaintenanceInjector.java
@@ -1,0 +1,12 @@
+package DbMaintenance.modules;
+
+import utilities.Metrics;
+
+public class MaintenanceInjector {
+  public static PocketPollMaintenanceComponent getInjector(final Metrics metrics) {
+    return DaggerPocketPollMaintenanceComponent
+        .builder()
+        .pocketPollMaintenanceModule(new PocketPollMaintenanceModule(metrics))
+        .build();
+  }
+}

--- a/backEnd/src/main/java/DbMaintenance/modules/PocketPollMaintenanceComponent.java
+++ b/backEnd/src/main/java/DbMaintenance/modules/PocketPollMaintenanceComponent.java
@@ -1,0 +1,11 @@
+package DbMaintenance.modules;
+
+import DbMaintenance.controllers.KeyUserRatingsByVersionController;
+import dagger.Component;
+import javax.inject.Singleton;
+
+@Singleton
+@Component(modules = PocketPollMaintenanceModule.class)
+public interface PocketPollMaintenanceComponent {
+  void inject(KeyUserRatingsByVersionController keyUserRatingsByVersionController);
+}

--- a/backEnd/src/main/java/DbMaintenance/modules/PocketPollMaintenanceComponent.java
+++ b/backEnd/src/main/java/DbMaintenance/modules/PocketPollMaintenanceComponent.java
@@ -1,6 +1,6 @@
-package DbMaintenance.modules;
+package dbMaintenance.modules;
 
-import DbMaintenance.controllers.KeyUserRatingsByVersionController;
+import dbMaintenance.controllers.KeyUserRatingsByVersionController;
 import dagger.Component;
 import javax.inject.Singleton;
 

--- a/backEnd/src/main/java/DbMaintenance/modules/PocketPollMaintenanceModule.java
+++ b/backEnd/src/main/java/DbMaintenance/modules/PocketPollMaintenanceModule.java
@@ -1,0 +1,28 @@
+package DbMaintenance.modules;
+
+import DbMaintenance.Managers.MaintenanceDbAccessManager;
+import DbMaintenance.handlers.KeyUserRatingsByVersionHandler;
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import utilities.Metrics;
+
+@Module
+@RequiredArgsConstructor
+public class PocketPollMaintenanceModule {
+
+  private final Metrics metrics;
+
+  @Provides
+  @Singleton
+  public MaintenanceDbAccessManager provideMaintenanceDbAccessManager() {
+    return new MaintenanceDbAccessManager();
+  }
+
+  @Provides
+  public KeyUserRatingsByVersionHandler provideKeyUserRatingsByVersionHandler(
+      final MaintenanceDbAccessManager maintenanceDbAccessManager) {
+    return new KeyUserRatingsByVersionHandler(maintenanceDbAccessManager, this.metrics);
+  }
+}

--- a/backEnd/src/main/java/DbMaintenance/modules/PocketPollMaintenanceModule.java
+++ b/backEnd/src/main/java/DbMaintenance/modules/PocketPollMaintenanceModule.java
@@ -1,7 +1,7 @@
-package DbMaintenance.modules;
+package dbMaintenance.modules;
 
-import DbMaintenance.Managers.MaintenanceDbAccessManager;
-import DbMaintenance.handlers.KeyUserRatingsByVersionHandler;
+import dbMaintenance.managers.MaintenanceDbAccessManager;
+import dbMaintenance.handlers.KeyUserRatingsByVersionHandler;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Singleton;

--- a/backEnd/src/main/java/managers/DbAccessManager.java
+++ b/backEnd/src/main/java/managers/DbAccessManager.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import models.Category;
@@ -44,13 +45,16 @@ public class DbAccessManager {
   public static final String NUMBER_OF_PARTITIONS_ENV_KEY = "NUMBER_OF_PARTITIONS";
   public static final String DELIM = ";";
 
+  //making protected for extended classes
   private final Table groupsTable;
-  private final Table usersTable;
+  protected final Table usersTable;
   private final Table categoriesTable;
   private final Table pendingEventsTable;
 
   private final AmazonDynamoDBClient client;
   private final DateTimeFormatter dateTimeFormatter;
+
+  private final HashMap<String, Item> cache;
 
   public DbAccessManager() {
     final Regions region = Regions.US_EAST_2;
@@ -66,6 +70,8 @@ public class DbAccessManager {
     this.usersTable = dynamoDb.getTable(USERS_TABLE_NAME);
     this.categoriesTable = dynamoDb.getTable(CATEGORIES_TABLE_NAME);
     this.pendingEventsTable = dynamoDb.getTable(PENDING_EVENTS_TABLE_NAME);
+
+    this.cache = new HashMap<>();
   }
 
   public String now() {
@@ -83,11 +89,27 @@ public class DbAccessManager {
 
   public User getUser(final String username)
       throws NullPointerException, InvalidAttributeValueException {
-    return new User(this.usersTable.getItem(new PrimaryKey(USERS_PRIMARY_KEY, username)));
+    Item userItem;
+    if (this.cache.containsKey(username)) {
+      userItem = this.cache.get(username);
+    } else {
+      userItem = this.usersTable.getItem(new PrimaryKey(USERS_PRIMARY_KEY, username));
+      this.cache.put(username, userItem);
+    }
+
+    return new User(userItem);
   }
 
   public Item getUserItem(final String username) throws NullPointerException {
-    return this.usersTable.getItem(new PrimaryKey(USERS_PRIMARY_KEY, username));
+    Item userItem;
+    if (this.cache.containsKey(username)) {
+      userItem = this.cache.get(username);
+    } else {
+      userItem = this.usersTable.getItem(new PrimaryKey(USERS_PRIMARY_KEY, username));
+      this.cache.put(username, userItem);
+    }
+
+    return userItem;
   }
 
   public UpdateItemOutcome updateUser(final String username, final UpdateItemSpec updateItemSpec) {
@@ -105,12 +127,27 @@ public class DbAccessManager {
   }
 
   public Category getCategory(final String categoryId) throws NullPointerException {
-    return new Category(
-        this.categoriesTable.getItem(new PrimaryKey(CATEGORIES_PRIMARY_KEY, categoryId)));
+    Item categoryItem;
+    if (this.cache.containsKey(categoryId)) {
+      categoryItem = this.cache.get(categoryId);
+    } else {
+      categoryItem = this.usersTable.getItem(new PrimaryKey(CATEGORIES_PRIMARY_KEY, categoryId));
+      this.cache.put(categoryId, categoryItem);
+    }
+
+    return new Category(categoryItem);
   }
 
-  public Map<String, Object> getCategoryMap(final String categoryId) {
-    return this.getCategory(categoryId).asMap();
+  public Item getCategoryItem(final String categoryId) throws NullPointerException {
+    Item categoryItem;
+    if (this.cache.containsKey(categoryId)) {
+      categoryItem = this.cache.get(categoryId);
+    } else {
+      categoryItem = this.usersTable.getItem(new PrimaryKey(CATEGORIES_PRIMARY_KEY, categoryId));
+      this.cache.put(categoryId, categoryItem);
+    }
+
+    return categoryItem;
   }
 
   public UpdateItemOutcome updateCategory(final String categoryId,

--- a/backEnd/src/main/java/managers/DbAccessManager.java
+++ b/backEnd/src/main/java/managers/DbAccessManager.java
@@ -131,7 +131,8 @@ public class DbAccessManager {
     if (this.cache.containsKey(categoryId)) {
       categoryItem = this.cache.get(categoryId);
     } else {
-      categoryItem = this.usersTable.getItem(new PrimaryKey(CATEGORIES_PRIMARY_KEY, categoryId));
+      categoryItem = this.categoriesTable
+          .getItem(new PrimaryKey(CATEGORIES_PRIMARY_KEY, categoryId));
       this.cache.put(categoryId, categoryItem);
     }
 
@@ -143,7 +144,8 @@ public class DbAccessManager {
     if (this.cache.containsKey(categoryId)) {
       categoryItem = this.cache.get(categoryId);
     } else {
-      categoryItem = this.usersTable.getItem(new PrimaryKey(CATEGORIES_PRIMARY_KEY, categoryId));
+      categoryItem = this.categoriesTable
+          .getItem(new PrimaryKey(CATEGORIES_PRIMARY_KEY, categoryId));
       this.cache.put(categoryId, categoryItem);
     }
 


### PR DESCRIPTION
## Summary
Since we've edited the structure of our data, I devised a method to update the existing data to update to this new structure. I created a DbMaintenance directory in which all of the logic for preforming these types of things exist. I have one handler that is going to update the user category ratings to be keyed by version number. For this update, the assumption is that any existing ratings are for the most up to date version of the category. 

In the pom.xml I exclude this DbMaintenance directory from the compilation. The idea is that this shouldn't be part of the real package, but instead this should be specifically built in when we need to maintenance. So I'll go into the pom, comment out the exclude, build and deploy to the Maintenance lambda (I'll be making a new lambda just to handle these types of executions) and then execute. In this way, the Maintenance code will never effect our real live lambdas or be able to be ran from our live lambdas.

## Testing
I hope it'll work. I ran it using a hard coded iterator of just my user object ("johnplaysgolf") and it worked fine there so as long as the scan works as I believe it will based on documentation then I think we're all good.

## Deployment
Once this pull is approved, I'll wait to run the maintenance until the other pull is approved since those need to happen near simultaneously.

The steps are:
1. Run the db maintenance script.
2. Deploy the new category ratings/get categories code to the proxy endpoint.
3. Update the front end to handle the new api definitions (Josh).