### PR TITLE
Updated group category mappings to include the creator.

### DIFF
--- a/backEnd/src/main/java/controllers/CreateNewGroupController.java
+++ b/backEnd/src/main/java/controllers/CreateNewGroupController.java
@@ -34,7 +34,7 @@ public class CreateNewGroupController implements ApiRequestController {
         final String activeUser = (String) jsonMap.get(RequestFields.ACTIVE_USER);
         final String groupName = (String) jsonMap.get(Group.GROUP_NAME);
         final List<String> members = (List<String>) jsonMap.get(Group.MEMBERS);
-        final Map<String, Object> categories = (Map<String, Object>) jsonMap.get(Group.CATEGORIES); // TODO update to a list of catIds
+        final List<String> categories = (List<String>) jsonMap.get(Group.CATEGORIES);
         final Integer defaultVotingDuration = (Integer) jsonMap.get(Group.DEFAULT_VOTING_DURATION);
         final Integer defaultRsvpDuration = (Integer) jsonMap.get(Group.DEFAULT_RSVP_DURATION);
         final Boolean isOpen = (Boolean) jsonMap.get(Group.IS_OPEN);

--- a/backEnd/src/main/java/controllers/EditGroupController.java
+++ b/backEnd/src/main/java/controllers/EditGroupController.java
@@ -36,8 +36,7 @@ public class EditGroupController implements ApiRequestController {
         final String groupId = (String) jsonMap.get(Group.GROUP_ID);
         final String groupName = (String) jsonMap.get(Group.GROUP_NAME);
         final List<String> members = (List<String>) jsonMap.get(Group.MEMBERS);
-        final Map<String, Object> categories = (Map<String, Object>) jsonMap
-            .get(Group.CATEGORIES); // TODO update to a list of catIds
+        final List<String> categories = (List<String>) jsonMap.get(Group.CATEGORIES);
         final Integer defaultVotingDuration = (Integer) jsonMap.get(Group.DEFAULT_VOTING_DURATION);
         final Integer defaultRsvpDuration = (Integer) jsonMap.get(Group.DEFAULT_RSVP_DURATION);
         final Boolean isOpen = (Boolean) jsonMap.get(Group.IS_OPEN);

--- a/backEnd/src/main/java/dbMaintenance/controllers/AddCategoryCreatorToGroupController.java
+++ b/backEnd/src/main/java/dbMaintenance/controllers/AddCategoryCreatorToGroupController.java
@@ -1,0 +1,35 @@
+package dbMaintenance.controllers;
+
+import controllers.ApiRequestController;
+import dbMaintenance.handlers.AddCategoryCreatorToGroupHandler;
+import dbMaintenance.modules.MaintenanceInjector;
+import exceptions.MissingApiRequestKeyException;
+import java.util.Map;
+import javax.inject.Inject;
+import utilities.ErrorDescriptor;
+import utilities.Metrics;
+import utilities.ResultStatus;
+
+public class AddCategoryCreatorToGroupController implements ApiRequestController {
+
+  @Inject
+  public AddCategoryCreatorToGroupHandler addCategoryCreatorToGroupHandler;
+
+  @Override
+  public ResultStatus processApiRequest(final Map<String, Object> jsonMap, final Metrics metrics)
+      throws MissingApiRequestKeyException {
+    final String classMethod = "AddCategoryCreatorToGroupController.processApiRequest";
+
+    ResultStatus resultStatus;
+
+    try {
+      MaintenanceInjector.getInjector(metrics).inject(this);
+      resultStatus = this.addCategoryCreatorToGroupHandler.handle();
+    } catch (final Exception e) {
+      metrics.logWithBody(new ErrorDescriptor<>(classMethod, e));
+      resultStatus = ResultStatus.failure("Exception in " + classMethod);
+    }
+
+    return resultStatus;
+  }
+}

--- a/backEnd/src/main/java/dbMaintenance/controllers/DbMaintenanceController.java
+++ b/backEnd/src/main/java/dbMaintenance/controllers/DbMaintenanceController.java
@@ -23,6 +23,7 @@ public class DbMaintenanceController implements
   private static final Map<String, Class<? extends ApiRequestController>> ACTIONS_TO_CONTROLLERS = Maps
       .newHashMap(ImmutableMap.<String, Class<? extends ApiRequestController>>builder()
           .put("keyUserRatingsByVersion", KeyUserRatingsByVersionController.class)
+          .put("addCategoryCreatorToGroup", AddCategoryCreatorToGroupController.class)
           .build());
 
   public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent request,

--- a/backEnd/src/main/java/dbMaintenance/handlers/AddCategoryCreatorToGroupHandler.java
+++ b/backEnd/src/main/java/dbMaintenance/handlers/AddCategoryCreatorToGroupHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
 import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
 import dbMaintenance.managers.MaintenanceDbAccessManager;
 import handlers.ApiRequestHandler;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 import models.Group;
@@ -41,7 +42,7 @@ public class AddCategoryCreatorToGroupHandler implements ApiRequestHandler {
         try {
           final String groupId = groupItem.getString(Group.GROUP_ID);
 
-          if (groupId.equals("testing group id")) {
+          if (groupId.equals("1372b335-1d44-4d68-9d55-ccf7a954909d")) {
             continue; // I tested on this group, so no need to reprocess
           }
 

--- a/backEnd/src/main/java/dbMaintenance/handlers/AddCategoryCreatorToGroupHandler.java
+++ b/backEnd/src/main/java/dbMaintenance/handlers/AddCategoryCreatorToGroupHandler.java
@@ -1,0 +1,101 @@
+package dbMaintenance.handlers;
+
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
+import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
+import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
+import dbMaintenance.managers.MaintenanceDbAccessManager;
+import handlers.ApiRequestHandler;
+import java.util.Iterator;
+import java.util.Map;
+import models.Group;
+import models.GroupCategory;
+import utilities.ErrorDescriptor;
+import utilities.Metrics;
+import utilities.ResultStatus;
+
+public class AddCategoryCreatorToGroupHandler implements ApiRequestHandler {
+
+  private final MaintenanceDbAccessManager maintenanceDbAccessManager;
+  private final Metrics metrics;
+
+  public AddCategoryCreatorToGroupHandler(
+      final MaintenanceDbAccessManager maintenanceDbAccessManager, final Metrics metrics) {
+    this.maintenanceDbAccessManager = maintenanceDbAccessManager;
+    this.metrics = metrics;
+  }
+
+  public ResultStatus handle() {
+    final String classMethod = "AddCategoryCreatorToGroupHandler.handle";
+    this.metrics.commonSetup(classMethod);
+
+    ResultStatus resultStatus = ResultStatus
+        .successful("Category Creators added to groups successfully.");
+
+    try {
+      final Iterator<Item> tableItems = this.maintenanceDbAccessManager.scanUsersTable();
+
+      while (tableItems.hasNext()) {
+        final Item groupItem = tableItems.next();
+
+        try {
+          final String groupId = groupItem.getString(Group.GROUP_ID);
+
+          if (groupId.equals("testing group id")) {
+            continue; // I tested on this group, so no need to reprocess
+          }
+
+          final Map<String, Object> oldCategoriesMap = groupItem.getMap(Group.CATEGORIES);
+
+          for (final String categoryId : oldCategoriesMap.keySet()) {
+            try {
+              final Item categoryItem = this.maintenanceDbAccessManager.getCategoryItem(categoryId);
+
+              if (categoryItem != null) {
+                //The category exists, create a GroupCategory out of it and let it fly
+
+                final GroupCategory groupCategory = new GroupCategory(categoryItem.asMap());
+
+                final String updateExpression =
+                    "Set " + Group.CATEGORIES + ".#categoryId = :catMap";
+                final NameMap nameMap = new NameMap().with("#categoryId", categoryId);
+                final ValueMap valueMap = new ValueMap()
+                    .withMap(":catMap", groupCategory.asMap());
+
+                final UpdateItemSpec updateItemSpec = new UpdateItemSpec()
+                    .withUpdateExpression(updateExpression)
+                    .withNameMap(nameMap)
+                    .withValueMap(valueMap);
+
+                this.maintenanceDbAccessManager.updateGroup(groupId, updateItemSpec);
+              } else {
+                //The category couldn't be found. Assume it was deleted and delete the entry.
+                //NOTE: This shouldn't be possible in our current schema
+                final String updateExpression = "remove " + Group.CATEGORIES + ".#categoryId";
+                final NameMap nameMap = new NameMap().with("#categoryId", categoryId);
+
+                final UpdateItemSpec updateItemSpec = new UpdateItemSpec()
+                    .withUpdateExpression(updateExpression)
+                    .withNameMap(nameMap);
+
+                this.maintenanceDbAccessManager.updateGroup(groupId, updateItemSpec);
+              }
+            } catch (final Exception e) {
+              this.metrics.log(new ErrorDescriptor<>(groupId + " " + categoryId, classMethod, e));
+              resultStatus = ResultStatus.failure("Exception in " + classMethod);
+            }
+          }
+        } catch (final Exception e) {
+          this.metrics.log(new ErrorDescriptor<>(groupItem.get(Group.GROUP_ID), classMethod, e));
+          resultStatus = ResultStatus.failure("Exception in " + classMethod);
+        }
+      }
+    } catch (final Exception e) {
+      this.metrics.logWithBody(new ErrorDescriptor<>(classMethod, e));
+      resultStatus = ResultStatus.failure("Exception in " + classMethod);
+    }
+
+    this.metrics.commonClose(resultStatus.success);
+    return resultStatus;
+  }
+}

--- a/backEnd/src/main/java/dbMaintenance/managers/MaintenanceDbAccessManager.java
+++ b/backEnd/src/main/java/dbMaintenance/managers/MaintenanceDbAccessManager.java
@@ -13,4 +13,8 @@ public class MaintenanceDbAccessManager extends DbAccessManager {
   public Iterator<Item> scanUsersTable() {
     return this.usersTable.scan().iterator();
   }
+
+  public Iterator<Item> scanGroupsTable() {
+    return this.groupsTable.scan().iterator();
+  }
 }

--- a/backEnd/src/main/java/dbMaintenance/modules/PocketPollMaintenanceComponent.java
+++ b/backEnd/src/main/java/dbMaintenance/modules/PocketPollMaintenanceComponent.java
@@ -1,5 +1,6 @@
 package dbMaintenance.modules;
 
+import dbMaintenance.controllers.AddCategoryCreatorToGroupController;
 import dbMaintenance.controllers.KeyUserRatingsByVersionController;
 import dagger.Component;
 import javax.inject.Singleton;
@@ -8,4 +9,5 @@ import javax.inject.Singleton;
 @Component(modules = PocketPollMaintenanceModule.class)
 public interface PocketPollMaintenanceComponent {
   void inject(KeyUserRatingsByVersionController keyUserRatingsByVersionController);
+  void inject(AddCategoryCreatorToGroupController addCategoryCreatorToGroupController);
 }

--- a/backEnd/src/main/java/dbMaintenance/modules/PocketPollMaintenanceModule.java
+++ b/backEnd/src/main/java/dbMaintenance/modules/PocketPollMaintenanceModule.java
@@ -1,5 +1,6 @@
 package dbMaintenance.modules;
 
+import dbMaintenance.handlers.AddCategoryCreatorToGroupHandler;
 import dbMaintenance.managers.MaintenanceDbAccessManager;
 import dbMaintenance.handlers.KeyUserRatingsByVersionHandler;
 import dagger.Module;
@@ -24,5 +25,11 @@ public class PocketPollMaintenanceModule {
   public KeyUserRatingsByVersionHandler provideKeyUserRatingsByVersionHandler(
       final MaintenanceDbAccessManager maintenanceDbAccessManager) {
     return new KeyUserRatingsByVersionHandler(maintenanceDbAccessManager, this.metrics);
+  }
+
+  @Provides
+  public AddCategoryCreatorToGroupHandler provideAddCategoryCreatorToGroupHandler(
+      final MaintenanceDbAccessManager maintenanceDbAccessManager) {
+    return new AddCategoryCreatorToGroupHandler(maintenanceDbAccessManager, this.metrics);
   }
 }

--- a/backEnd/src/main/java/managers/DbAccessManager.java
+++ b/backEnd/src/main/java/managers/DbAccessManager.java
@@ -46,7 +46,7 @@ public class DbAccessManager {
   public static final String DELIM = ";";
 
   //making protected for extended classes
-  private final Table groupsTable;
+  protected final Table groupsTable;
   protected final Table usersTable;
   private final Table categoriesTable;
   private final Table pendingEventsTable;

--- a/backEnd/src/main/java/models/Group.java
+++ b/backEnd/src/main/java/models/Group.java
@@ -38,13 +38,12 @@ public class Group implements Model {
   private String lastActivity;
   private Map<String, Event> events;
   private boolean isOpen;
+  private Map<String, GroupCategory> categories;
 
   @Setter(AccessLevel.NONE)
   private Map<String, Member> members;
   @Setter(AccessLevel.NONE)
   private Map<String, Boolean> membersLeft;
-  @Setter(AccessLevel.NONE)
-  private Map<String, String> categories;
 
   public Group(final Item groupItem) {
     this(groupItem.asMap());
@@ -64,7 +63,7 @@ public class Group implements Model {
 
     this.setMembers((Map<String, Object>) jsonMap.get(MEMBERS));
     this.setMembersLeft((Map<String, Object>) jsonMap.get(MEMBERS_LEFT));
-    this.setCategories((Map<String, Object>) jsonMap.get(CATEGORIES));
+    this.setCategoriesRawMap((Map<String, Object>) jsonMap.get(CATEGORIES));
     this.setEventsRawMap((Map<String, Object>) jsonMap.get(EVENTS));
   }
 
@@ -97,7 +96,7 @@ public class Group implements Model {
     modelAsMap.putIfAbsent(IS_OPEN, this.isOpen);
     modelAsMap.putIfAbsent(MEMBERS, this.getMembersMap());
     modelAsMap.putIfAbsent(MEMBERS_LEFT, this.membersLeft);
-    modelAsMap.putIfAbsent(CATEGORIES, this.categories);
+    modelAsMap.putIfAbsent(CATEGORIES, this.getCategoriesMap());
     modelAsMap.putIfAbsent(EVENTS, this.getEventsMap());
     return modelAsMap;
   }
@@ -124,18 +123,27 @@ public class Group implements Model {
 
   public Map<String, Map<String, String>> getMembersMap() {
     final Map<String, Map<String, String>> membersMapped = new HashMap<>();
-    for (String username : this.members.keySet()) {
+    for (final String username : this.members.keySet()) {
       membersMapped.putIfAbsent(username, this.members.get(username).asMap());
     }
     return membersMapped;
   }
 
-  public void setCategories(final Map<String, Object> jsonMap) {
+  public Map<String, Map<String, Object>> getCategoriesMap() {
+    final Map<String, Map<String, Object>> categoriesMapped = new HashMap<>();
+    for (final String categoryId : this.categories.keySet()) {
+      categoriesMapped.putIfAbsent(categoryId, this.categories.get(categoryId).asMap());
+    }
+    return categoriesMapped;
+  }
+
+  public void setCategoriesRawMap(final Map<String, Object> jsonMap) {
     this.categories = null;
     if (jsonMap != null) {
       this.categories = new HashMap<>();
       for (String categoryId : jsonMap.keySet()) {
-        this.categories.putIfAbsent(categoryId, (String) jsonMap.get(categoryId));
+        this.categories.putIfAbsent(categoryId,
+            new GroupCategory((Map<String, Object>) jsonMap.get(categoryId)));
       }
     }
   }
@@ -158,16 +166,8 @@ public class Group implements Model {
     return eventsMapped;
   }
 
-  public boolean groupNameIsSet() {
-    return this.groupName != null;
-  }
-
   public boolean iconIsSet() {
     return this.icon != null;
-  }
-
-  public boolean lastActivityIsSet() {
-    return this.lastActivity != null;
   }
 
   public Group clone() {

--- a/backEnd/src/main/java/models/GroupCategory.java
+++ b/backEnd/src/main/java/models/GroupCategory.java
@@ -1,0 +1,24 @@
+package models;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class GroupCategory {
+
+  private String categoryName;
+  private String owner;
+
+  public GroupCategory(final Map<String, Object> jsonMap) {
+    this.categoryName = (String) jsonMap.get(Category.CATEGORY_NAME);
+    this.owner = (String) jsonMap.get(Category.OWNER);
+  }
+
+  public Map<String, Object> asMap() {
+    final Map<String, Object> modelAsMap = new HashMap<>();
+    modelAsMap.putIfAbsent(Category.CATEGORY_NAME, this.categoryName);
+    modelAsMap.putIfAbsent(Category.OWNER, this.owner);
+    return modelAsMap;
+  }
+}

--- a/backEnd/src/test/java/handlers/EditCategoryHandlerTest.java
+++ b/backEnd/src/test/java/handlers/EditCategoryHandlerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItem;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -92,10 +93,12 @@ public class EditCategoryHandlerTest {
       verify(this.dbAccessManager).executeWriteTransaction(argument.capture());
       assertEquals(2, argument.getValue().size());
 
-      assertEquals(3, mockingDetails(this.dbAccessManager).getInvocations().size());
+      assertEquals(6, mockingDetails(this.dbAccessManager).getInvocations().size());
       verify(this.dbAccessManager, times(1)).executeWriteTransaction(any(List.class));
       verify(this.dbAccessManager, times(1)).getCategory(any(String.class));
       verify(this.dbAccessManager, times(1)).getUser(any(String.class));
+      verify(this.dbAccessManager, times(3))
+          .updateGroup(any(String.class), any(UpdateItemSpec.class));
       verify(this.metrics, times(2)).commonClose(true);
     } catch (final Exception e) {
       System.out.println(e);

--- a/front_end_pocket_poll/lib/groups_widgets/group_categories.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_categories.dart
@@ -7,11 +7,12 @@ import 'package:front_end_pocket_poll/imports/groups_manager.dart';
 import 'package:front_end_pocket_poll/imports/result_status.dart';
 import 'package:front_end_pocket_poll/imports/users_manager.dart';
 import 'package:front_end_pocket_poll/models/category.dart';
+import 'package:front_end_pocket_poll/models/group_category.dart';
 import 'package:front_end_pocket_poll/widgets/category_row_group.dart';
 
 class GroupCategories extends StatefulWidget {
-  final Map<String, String>
-      selectedCategories; // map of categoryIds -> categoryName
+  final Map<String, GroupCategory>
+      selectedCategories; // map of categoryIds -> GroupCategory
   final bool canEdit;
 
   GroupCategories({this.selectedCategories, this.canEdit});
@@ -317,12 +318,12 @@ class _GroupCategoriesState extends State<GroupCategories> {
   }
 
   // adds this category to the list of selected (i.e. adds it to the group)
-  void selectCategory(Category category) {
+  void selectCategory(final Category category) {
     if (widget.selectedCategories.keys.contains(category.categoryId)) {
       widget.selectedCategories.remove(category.categoryId);
     } else {
       widget.selectedCategories
-          .putIfAbsent(category.categoryId, () => category.categoryName);
+          .putIfAbsent(category.categoryId, () => category.asGroupCategory());
     }
     this.buildCategoryRows();
   }

--- a/front_end_pocket_poll/lib/groups_widgets/group_settings.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_settings.dart
@@ -7,6 +7,7 @@ import 'package:front_end_pocket_poll/imports/globals.dart';
 import 'package:front_end_pocket_poll/imports/groups_manager.dart';
 import 'package:front_end_pocket_poll/imports/result_status.dart';
 import 'package:front_end_pocket_poll/models/group.dart';
+import 'package:front_end_pocket_poll/models/group_category.dart';
 import 'package:front_end_pocket_poll/models/group_left.dart';
 import 'package:front_end_pocket_poll/models/member.dart';
 import 'package:front_end_pocket_poll/utilities/validator.dart';
@@ -38,8 +39,10 @@ class _GroupSettingsState extends State<GroupSettings> {
   List<Member> originalMembers;
   List<Member> displayedMembers;
   List<String> membersLeft; // list of usernames
-  Map<String, String> selectedCategories; // map of categoryIds -> categoryName
-  Map<String, String> originalCategories; // map of categoryIds -> categoryName
+  Map<String, GroupCategory>
+      selectedCategories; // map of categoryIds -> GroupCategory
+  Map<String, GroupCategory>
+      originalCategories; // map of categoryIds -> GroupCategory
 
   final GlobalKey<FormState> formKey = new GlobalKey<FormState>();
   final TextEditingController groupNameController = new TextEditingController();
@@ -65,8 +68,8 @@ class _GroupSettingsState extends State<GroupSettings> {
     this.originalMembers = new List<Member>();
     this.displayedMembers = new List<Member>();
     this.membersLeft = new List<String>();
-    this.originalCategories = new Map<String, String>();
-    this.selectedCategories = new Map<String, String>();
+    this.originalCategories = new Map<String, GroupCategory>();
+    this.selectedCategories = new Map<String, GroupCategory>();
 
     if (Globals.username == Globals.currentGroup.groupCreator) {
       // to display the delete group button, check if user owns this group
@@ -640,8 +643,8 @@ class _GroupSettingsState extends State<GroupSettings> {
                 },
               )
             ],
-            content:
-                Text("Are you sure you wish to leave the group \"$groupName\"?"),
+            content: Text(
+                "Are you sure you wish to leave the group \"$groupName\"?"),
           );
         });
   }

--- a/front_end_pocket_poll/lib/groups_widgets/groups_create.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/groups_create.dart
@@ -6,6 +6,7 @@ import 'package:front_end_pocket_poll/imports/globals.dart';
 import 'package:front_end_pocket_poll/imports/result_status.dart';
 import 'package:front_end_pocket_poll/models/event.dart';
 import 'package:front_end_pocket_poll/models/group.dart';
+import 'package:front_end_pocket_poll/models/group_category.dart';
 import 'package:front_end_pocket_poll/models/member.dart';
 import 'package:front_end_pocket_poll/models/user_group.dart';
 import 'package:front_end_pocket_poll/utilities/utilities.dart';
@@ -39,8 +40,8 @@ class _CreateGroupState extends State<CreateGroup> {
   FocusNode considerFocus;
   FocusNode votingFocus;
 
-  // map of categoryIds -> categoryName
-  Map<String, String> groupCategories = new Map<String, String>();
+  // map of categoryIds -> GroupCategory
+  Map<String, GroupCategory> groupCategories = new Map<String, GroupCategory>();
 
   @override
   void initState() {

--- a/front_end_pocket_poll/lib/imports/groups_manager.dart
+++ b/front_end_pocket_poll/lib/imports/groups_manager.dart
@@ -136,6 +136,8 @@ class GroupsManager {
     }
     jsonRequestBody[RequestFields.PAYLOAD][MEMBERS] =
         group.members.keys.toList();
+    jsonRequestBody[RequestFields.PAYLOAD][CATEGORIES] =
+        group.categories.keys.toList();
 
     ResultStatus<String> response =
         await makeApiRequest(apiEndpoint, jsonRequestBody);
@@ -180,6 +182,8 @@ class GroupsManager {
 
     jsonRequestBody[RequestFields.PAYLOAD][MEMBERS] =
         group.members.keys.toList();
+    jsonRequestBody[RequestFields.PAYLOAD][CATEGORIES] =
+        group.categories.keys.toList();
 
     if (batchNumber == null) {
       // batchNumber is used to get a discrete number of events from the DB

--- a/front_end_pocket_poll/lib/models/category.dart
+++ b/front_end_pocket_poll/lib/models/category.dart
@@ -1,5 +1,7 @@
 import 'package:front_end_pocket_poll/imports/categories_manager.dart';
 
+import 'group_category.dart';
+
 class Category {
   final String categoryName;
   final String categoryId;
@@ -47,6 +49,11 @@ class Category {
   factory Category.fromJsonUser(Map<String, dynamic> json) {
     return Category(
         categoryId: json['CategoryId'], categoryName: json['CategoryName']);
+  }
+
+  GroupCategory asGroupCategory() {
+    return new GroupCategory(
+        categoryName: this.categoryName, owner: this.owner);
   }
 
   @override

--- a/front_end_pocket_poll/lib/models/group.dart
+++ b/front_end_pocket_poll/lib/models/group.dart
@@ -4,6 +4,8 @@ import 'package:front_end_pocket_poll/imports/groups_manager.dart';
 import 'package:front_end_pocket_poll/models/event.dart';
 import 'package:front_end_pocket_poll/models/member.dart';
 
+import 'group_category.dart';
+
 class Group {
   final String groupId;
   final String groupName;
@@ -12,7 +14,7 @@ class Group {
   final String lastActivity;
   final Map<String, Member> members;
   final Map<String, bool> membersLeft;
-  final Map<String, String> categories;
+  final Map<String, GroupCategory> categories;
   final Map<String, Event> events;
   final int defaultVotingDuration;
   final int defaultConsiderDuration;
@@ -65,7 +67,7 @@ class Group {
         key: (k) => k, value: (k) => events[k]);
     events = sortedMap.cast();
 
-    // map of username -> member
+    // map of username -> Member
     Map<String, Member> memberMap = new Map<String, Member>();
     for (String username in json[GroupsManager.MEMBERS].keys) {
       Member member =
@@ -73,17 +75,18 @@ class Group {
       memberMap.putIfAbsent(username, () => member);
     }
 
+    // map of categoryId -> GroupCategory
+    Map<String, GroupCategory> categoriesMap = new Map<String, GroupCategory>();
+    for (String categoryId in json[GroupsManager.CATEGORIES].keys) {
+      GroupCategory groupCategory = new GroupCategory.fromJson(
+          json[GroupsManager.CATEGORIES][categoryId]);
+      categoriesMap.putIfAbsent(categoryId, () => groupCategory);
+    }
+
     Map<String, bool> membersLeftMap = new Map<String, bool>();
     for (String username in json[GroupsManager.MEMBERS_LEFT].keys) {
       membersLeftMap.putIfAbsent(
           username, () => json[GroupsManager.MEMBERS_LEFT][username]);
-    }
-
-    // map of category id to category category name
-    Map<String, String> categoriesMap = new Map<String, String>();
-    for (String categoryId in json[GroupsManager.CATEGORIES].keys) {
-      categoriesMap.putIfAbsent(categoryId,
-          () => json[GroupsManager.CATEGORIES][categoryId].toString());
     }
 
     return Group(

--- a/front_end_pocket_poll/lib/models/group_category.dart
+++ b/front_end_pocket_poll/lib/models/group_category.dart
@@ -1,0 +1,37 @@
+import 'package:front_end_pocket_poll/imports/categories_manager.dart';
+
+import 'category.dart';
+
+class GroupCategory {
+  final String categoryName;
+  final String owner;
+
+  GroupCategory({this.categoryName, this.owner});
+
+  GroupCategory.debug(this.categoryName, this.owner);
+
+  factory GroupCategory.fromJson(final Map<String, dynamic> json) {
+    return GroupCategory(
+        categoryName: json[CategoriesManager.CATEGORY_NAME],
+        owner: json[CategoriesManager.OWNER]);
+  }
+
+  factory GroupCategory.fromCategory(final Category category) {
+    return GroupCategory(
+      categoryName: category.categoryName,
+      owner: category.owner
+    );
+  }
+
+  Map asMap() {
+    return {
+      CategoriesManager.CATEGORY_NAME: this.categoryName,
+      CategoriesManager.OWNER: this.owner
+    };
+  }
+
+  @override
+  String toString() {
+    return "CategoryName: $categoryName Owner: $owner";
+  }
+}

--- a/front_end_pocket_poll/lib/widgets/category_pick.dart
+++ b/front_end_pocket_poll/lib/widgets/category_pick.dart
@@ -2,12 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:front_end_pocket_poll/categories_widgets/categories_home.dart';
 import 'package:front_end_pocket_poll/imports/globals.dart';
 import 'package:front_end_pocket_poll/models/category.dart';
+import 'package:front_end_pocket_poll/models/group_category.dart';
 
 import 'category_row.dart';
 
 class CategoryPick extends StatefulWidget {
-  final Map<String, String>
-      selectedCategories; // map of categoryIds -> categoryName
+  final Map<String, GroupCategory>
+      selectedCategories; // map of categoryIds -> GroupCategory
 
   CategoryPick(this.selectedCategories);
 
@@ -95,13 +96,13 @@ class _CategoryPickState extends State<CategoryPick> {
   }
 
   // select a category to be added or, if it already selected, remove it from the selection
-  void selectCategory(Category category) {
+  void selectCategory(final Category category) {
     setState(() {
       if (widget.selectedCategories.keys.contains(category.categoryId)) {
         widget.selectedCategories.remove(category.categoryId);
       } else {
         widget.selectedCategories
-            .putIfAbsent(category.categoryId, () => category.categoryName);
+            .putIfAbsent(category.categoryId, () => category.asGroupCategory());
       }
 
       this.loadCategoryRows();


### PR DESCRIPTION
## Summary
I did the following:
1. I updated the creation of the groups/the editing of groups to accept lists of category ids (vs entire category maps). In this way we control building the category maps based on definite db values. In addition, this allowed for me to control the structure of the map that we insert for the group.

2. I updated the Group model to have the categories be a map from category id to GroupCategory. This new model is akin to the Member model where it is a lightweight model used to encapsulate a map of data. This GroupCategory has two 'keys' (member variables) for the category name and the owner.

3. I created a db maintenance script that loops over all of the groups and subsequently all of the categories within said groups. In updates the mappings for each category id to go from just the string category name to the new GroupCategory map.

4. I updated the front end api requests for add/edit group to pass the list of category ids instead of the maps that were being sent before.

5. I updated the front end group model to match the new back end architecture.

6. I added code in the edit category handler to updated denormalized category name in the group object. I'm not really sure how this code never got in place before. I assume it's because we were always querying the category data directory on the front end, but anyways it's there now and that's all that matters.

## Testing
I ran the db maintenance on this group: 1372b335-1d44-4d68-9d55-ccf7a954909d and based on the logs and the dynamo db, everything went as intended.

With the aforementioned test group, I tested the getGroup endpoint and it worked successfully - it's Categories map was mapping to the new category name/creator maps as intended.

I ran the app and made sure that I could open my test group.