### PR TITLE
Cron job for removed detached user category ratings has been added.

### DIFF
--- a/backEnd/src/main/java/dbMaintenance/cronJobs/controllers/CronJobController.java
+++ b/backEnd/src/main/java/dbMaintenance/cronJobs/controllers/CronJobController.java
@@ -1,0 +1,96 @@
+package dbMaintenance.cronJobs.controllers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import controllers.ApiRequestController;
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+import utilities.ErrorDescriptor;
+import utilities.GetActiveUser;
+import utilities.JsonUtils;
+import utilities.Metrics;
+import utilities.RequestFields;
+import utilities.ResultStatus;
+import utilities.WarningDescriptor;
+
+public class CronJobController implements
+    RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+  private static final Map<String, Class<? extends ApiRequestController>> ACTIONS_TO_CONTROLLERS = Maps
+      .newHashMap(ImmutableMap.<String, Class<? extends ApiRequestController>>builder()
+          .put("detachedRatingsRemoval", DetachedRatingsRemovalController.class)
+          .build());
+
+  public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent request,
+      Context context) {
+    final String classMethod = "CronJobController.handleRequest";
+
+    final Metrics metrics = new Metrics(context.getAwsRequestId(), context.getLogger());
+    metrics.commonSetup(classMethod);
+
+    ResultStatus resultStatus;
+
+    try {
+      String action = request.getPath(); // this should be of the form '/action'
+      String[] splitAction = action.split("/"); // remove the prefixed slash
+
+      if (splitAction.length == 2) {
+        action = splitAction[1]; // the action is after the '/'
+
+        if (ACTIONS_TO_CONTROLLERS.containsKey(action)) {
+          final Map<String, Object> jsonMap = JsonUtils.parseInput(request.getBody());
+          metrics.setRequestBody(jsonMap); // attach here for logging before handling action
+
+          if (!jsonMap.containsKey(RequestFields.ACTIVE_USER)) {
+            //get the active user from the authorization header and put it in the request payload
+            jsonMap.put(RequestFields.ACTIVE_USER,
+                GetActiveUser.getActiveUserFromRequest(request, context));
+
+            final Class<? extends ApiRequestController> actionHandlerClass = ACTIONS_TO_CONTROLLERS
+                .get(action);
+            final Constructor c = actionHandlerClass.getConstructor(); // get the default
+            final ApiRequestController apiRequestHandler = (ApiRequestController) c.newInstance();
+            resultStatus = apiRequestHandler.processApiRequest(jsonMap, metrics);
+          } else {
+            //bad request body, log warning
+            resultStatus = ResultStatus.failure("Error: Bad request body.");
+          }
+        } else {
+          metrics.log(new WarningDescriptor<>(
+              new HashMap<String, Object>() {{
+                put("path", request.getPath());
+                put("body", request.getBody());
+              }},
+              classMethod, "Unknown action."));
+          resultStatus = ResultStatus.failure("Error: Unknown action.");
+        }
+      } else {
+        metrics.log(new WarningDescriptor<>(
+            new HashMap<String, Object>() {{
+              put("path", request.getPath());
+              put("body", request.getBody());
+            }},
+            classMethod, "Bad request format."));
+        resultStatus = ResultStatus.failure("Error: Bad request format.");
+      }
+    } catch (final Exception e) {
+      metrics.log(new ErrorDescriptor<>(
+          new HashMap<String, Object>() {{
+            put("path", request.getPath());
+            put("body", request.getBody());
+          }},
+          classMethod, e));
+      resultStatus = ResultStatus.failure("Error: Exception occurred.");
+    }
+
+    metrics.commonClose(resultStatus.success);
+    metrics.logMetrics();
+
+    return new APIGatewayProxyResponseEvent().withBody(resultStatus.toString());
+  }
+}

--- a/backEnd/src/main/java/dbMaintenance/cronJobs/controllers/DetachedRatingsRemovalController.java
+++ b/backEnd/src/main/java/dbMaintenance/cronJobs/controllers/DetachedRatingsRemovalController.java
@@ -1,0 +1,35 @@
+package dbMaintenance.cronJobs.controllers;
+
+import controllers.ApiRequestController;
+import dbMaintenance.cronJobs.handlers.DetachedRatingsRemovalHandler;
+import dbMaintenance.modules.MaintenanceInjector;
+import exceptions.MissingApiRequestKeyException;
+import java.util.Map;
+import javax.inject.Inject;
+import utilities.ErrorDescriptor;
+import utilities.Metrics;
+import utilities.ResultStatus;
+
+public class DetachedRatingsRemovalController implements ApiRequestController {
+
+  @Inject
+  public DetachedRatingsRemovalHandler detachedRatingsRemovalHandler;
+
+  @Override
+  public ResultStatus processApiRequest(Map<String, Object> jsonMap, Metrics metrics)
+      throws MissingApiRequestKeyException {
+    final String classMethod = "DetachedRatingsRemovalController.processApiRequest";
+
+    ResultStatus resultStatus;
+
+    try {
+      MaintenanceInjector.getInjector(metrics).inject(this);
+      resultStatus = this.detachedRatingsRemovalHandler.handle();
+    } catch (final Exception e) {
+      metrics.logWithBody(new ErrorDescriptor<>(classMethod, e));
+      resultStatus = ResultStatus.failure("Exception in " + classMethod);
+    }
+
+    return resultStatus;
+  }
+}

--- a/backEnd/src/main/java/dbMaintenance/cronJobs/handlers/DetachedRatingsRemovalHandler.java
+++ b/backEnd/src/main/java/dbMaintenance/cronJobs/handlers/DetachedRatingsRemovalHandler.java
@@ -1,12 +1,24 @@
 package dbMaintenance.cronJobs.handlers;
 
+import static utilities.Config.PENDING_EVENTS_DELIM;
+
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
 import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
 import dbMaintenance.managers.MaintenanceDbAccessManager;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.inject.Inject;
+import managers.DbAccessManager;
+import models.Category;
+import models.Group;
 import models.User;
 import utilities.ErrorDescriptor;
 import utilities.Metrics;
@@ -39,38 +51,202 @@ public class DetachedRatingsRemovalHandler {
         .successful("Detached category ratings removed successfully.");
 
     try {
-      final Iterator<Item> tableItems = this.maintenanceDbAccessManager.scanUsersTable();
+      final Iterator<Item> pendingEventsTableItems = this.maintenanceDbAccessManager
+          .scanPendingEventsTable();
 
-      while (tableItems.hasNext()) {
-        final Item userItem = tableItems.next();
+      //The first thing we need to do is determine all of the category ids and the versions of said
+      // categories of the pending events in the system.
+      final HashMap<String, HashSet<String>> pendingEventCategoryIdsToVersionSets = new HashMap<>();
+
+      while (pendingEventsTableItems.hasNext()) {
+        final Map<String, Object> pendingEventsData = pendingEventsTableItems.next().asMap();
+
+        String groupId, eventId;
+        Group group;
+        List<String> keyPair;
+        for (String key : pendingEventsData.keySet()) {
+          //skip the scanner id key as it isn't real pending event data
+          if (!key.equals(DbAccessManager.PENDING_EVENTS_PRIMARY_KEY)) {
+            keyPair = Arrays.asList(key.split(PENDING_EVENTS_DELIM));
+
+            if (keyPair.size() == 2) {
+              groupId = keyPair.get(0);
+              eventId = keyPair.get(1);
+
+              group = this.maintenanceDbAccessManager.getGroup(groupId);
+
+              //add a hashset for the category if the category hasn't been mapped to yet
+              pendingEventCategoryIdsToVersionSets
+                  .putIfAbsent(group.getEvents().get(eventId).getCategoryId(), new HashSet<>());
+              //add the version to the set of pending category versions
+              pendingEventCategoryIdsToVersionSets
+                  .get(group.getEvents().get(eventId).getCategoryId())
+                  .add(group.getEvents().get(eventId).getCategoryVersion().toString());
+            } else {
+              metrics.log(new ErrorDescriptor<>(
+                  "scanner id: " + pendingEventsData.get(DbAccessManager.PENDING_EVENTS_PRIMARY_KEY)
+                      + ", key : " + key,
+                  classMethod, "bad format for key in pending events table"));
+              resultStatus = ResultStatus.failure("Bad key format in pending events partition.");
+            }
+          }
+        }
+      }
+
+      final Iterator<Item> userTableItems = this.maintenanceDbAccessManager.scanUsersTable();
+
+      while (userTableItems.hasNext()) {
+        final Item userItem = userTableItems.next();
 
         try {
-          final String username = userItem.getString(User.USERNAME);
+          final User user = new User(userItem);
+          final String username = user.getUsername();
 
           final StringBuilder updateExpressionBuilder = new StringBuilder();
           final NameMap nameMap = new NameMap();
 
-          final Map<String, Object> oldCategoryRatingsMap = userItem.getMap(User.CATEGORY_RATINGS);
-
           int i = 0;
-          for (final String categoryId : oldCategoryRatingsMap.keySet()) {
+          for (final String categoryId : user.getCategoryRatings().keySet()) {
             try {
               final Item categoryItem = this.maintenanceDbAccessManager.getCategoryItem(categoryId);
 
+              final String categoryIdName = "#categoryId" + i;
+              final String dotCategoryIdName = "." + categoryIdName;
+
               if (categoryItem == null) {
-                //The category does not exist, remove it's ratings from the user item
-                final String categoryIdName = "#categoryId" + i;
-                final String dotCategoryIdName = "." + categoryIdName;
+                //The category does not exist, remove non necessary ratings from the user item
 
-                if (updateExpressionBuilder.length() == 0) {
-                  updateExpressionBuilder.append("remove ").append(User.CATEGORY_RATINGS)
-                      .append(dotCategoryIdName);
+                if (pendingEventCategoryIdsToVersionSets.containsKey(categoryId)) {
+                  //check if user has ratings for one of the versions, if so we can remove all
+                  // mappings except those
+                  final Set<String> userCategoryVersionsToKeep = user.getCategoryRatings()
+                      .get(categoryId).getVersionSet();
+
+                  //do a set intersection with the existing user versions and the pending versions
+                  userCategoryVersionsToKeep
+                      .retainAll(pendingEventCategoryIdsToVersionSets.get(categoryId));
+
+                  if (userCategoryVersionsToKeep.size() > 0) {
+                    //some of the user's ratings for this deleted category are still pertinent for
+                    // pending events -> save those, delete everything else
+                    int j = 0;
+                    for (final String version : user.getCategoryRatings().get(categoryId)
+                        .getVersionSet()) {
+                      if (!userCategoryVersionsToKeep.contains(version)) {
+                        final String versionName = "#v_" + i + "_" + j;
+                        final String dotVersionName = "." + versionName;
+
+                        if (updateExpressionBuilder.length() == 0) {
+                          updateExpressionBuilder.append("remove ").append(User.CATEGORY_RATINGS)
+                              .append(dotCategoryIdName).append(dotVersionName);
+                        } else {
+                          updateExpressionBuilder.append(", ").append(User.CATEGORY_RATINGS)
+                              .append(dotCategoryIdName).append(dotVersionName);
+                        }
+
+                        nameMap.with(categoryIdName, categoryId);
+                        nameMap.with(versionName, version);
+                      }
+
+                      j++;
+                    }
+                  } else {
+                    //the user has no version maps saved for pending events associated with this
+                    // deleted category -> delete the users whole rating map for this category
+                    if (updateExpressionBuilder.length() == 0) {
+                      updateExpressionBuilder.append("remove ").append(User.CATEGORY_RATINGS)
+                          .append(dotCategoryIdName);
+                    } else {
+                      updateExpressionBuilder.append(", ").append(User.CATEGORY_RATINGS)
+                          .append(dotCategoryIdName);
+                    }
+
+                    nameMap.with(categoryIdName, categoryId);
+                  }
                 } else {
-                  updateExpressionBuilder.append(", ").append(User.CATEGORY_RATINGS)
-                      .append(dotCategoryIdName);
-                }
+                  //nothing pending so were good to remove the entire category mapping
+                  if (updateExpressionBuilder.length() == 0) {
+                    updateExpressionBuilder.append("remove ").append(User.CATEGORY_RATINGS)
+                        .append(dotCategoryIdName);
+                  } else {
+                    updateExpressionBuilder.append(", ").append(User.CATEGORY_RATINGS)
+                        .append(dotCategoryIdName);
+                  }
 
-                nameMap.with(categoryIdName, categoryId);
+                  nameMap.with(categoryIdName, categoryId);
+                }
+              } else {
+                //the category still exists, but we still need to check to see if the user still has
+                // old version mappings that can be removed
+
+                final String currentCategoryVersion = categoryItem.getInt(Category.VERSION) + "";
+
+                final Set<String> userCategoryVersions = user.getCategoryRatings().get(categoryId)
+                    .getVersionSet();
+
+                if (pendingEventCategoryIdsToVersionSets.containsKey(categoryId)) {
+                  //check if user has ratings for one of the versions, if so we can remove all
+                  // mappings except those and the most up to date version
+
+                  //add the current version since we definitely want to keep that if the user has it
+                  pendingEventCategoryIdsToVersionSets.get(categoryId).add(currentCategoryVersion);
+
+                  //do a set intersection with the existing user versions and the pending versions
+                  userCategoryVersions
+                      .retainAll(pendingEventCategoryIdsToVersionSets.get(categoryId));
+
+                  if (userCategoryVersions.size() > 0) {
+                    //some of the user's ratings for this deleted category are still pertinent for
+                    // pending events -> save those, delete everything else
+                    int j = 0;
+                    for (final String version : user.getCategoryRatings().get(categoryId)
+                        .getVersionSet()) {
+                      if (!userCategoryVersions.contains(version)) {
+                        final String versionName = "#v_" + i + "_" + j;
+                        final String dotVersionName = "." + versionName;
+
+                        if (updateExpressionBuilder.length() == 0) {
+                          updateExpressionBuilder.append("remove ").append(User.CATEGORY_RATINGS)
+                              .append(dotCategoryIdName).append(dotVersionName);
+                        } else {
+                          updateExpressionBuilder.append(", ").append(User.CATEGORY_RATINGS)
+                              .append(dotCategoryIdName).append(dotVersionName);
+                        }
+
+                        nameMap.with(categoryIdName, categoryId);
+                        nameMap.with(versionName, version);
+                      }
+
+                      j++;
+                    }
+                  } else {
+                    //the user has no version maps saved for pending events associated with this
+                    // category or the most current version of this category -> delete the user's
+                    // whole rating map for this category
+                    if (updateExpressionBuilder.length() == 0) {
+                      updateExpressionBuilder.append("remove ").append(User.CATEGORY_RATINGS)
+                          .append(dotCategoryIdName);
+                    } else {
+                      updateExpressionBuilder.append(", ").append(User.CATEGORY_RATINGS)
+                          .append(dotCategoryIdName);
+                    }
+
+                    nameMap.with(categoryIdName, categoryId);
+                  }
+                } else {
+                  //there are no pending events for this category, we can remove all ratings maps
+                  // except for the most up to date version
+                  if (userCategoryVersions.contains(currentCategoryVersion)) {
+                    //get the ratings that we need to save and overwrite this category map
+
+                    if (userCategoryVersions.size() > 1) {
+                      final Map 
+                    }
+                  } else {
+                    //the user doesn't have ratings for the most up to date category version, we can
+                    // delete their entire map for this category
+                  }
+                }
               }
             } catch (final Exception e) {
               this.metrics.log(new ErrorDescriptor<>(username + " " + categoryId, classMethod, e));

--- a/backEnd/src/main/java/dbMaintenance/cronJobs/handlers/DetachedRatingsRemovalHandler.java
+++ b/backEnd/src/main/java/dbMaintenance/cronJobs/handlers/DetachedRatingsRemovalHandler.java
@@ -4,9 +4,9 @@ import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
 import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
 import dbMaintenance.managers.MaintenanceDbAccessManager;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import javax.inject.Inject;
 import models.User;
 import utilities.ErrorDescriptor;
 import utilities.Metrics;
@@ -17,6 +17,7 @@ public class DetachedRatingsRemovalHandler {
   private MaintenanceDbAccessManager maintenanceDbAccessManager;
   private Metrics metrics;
 
+  @Inject
   public DetachedRatingsRemovalHandler(final MaintenanceDbAccessManager maintenanceDbAccessManager,
       final Metrics metrics) {
     this.maintenanceDbAccessManager = maintenanceDbAccessManager;

--- a/backEnd/src/main/java/dbMaintenance/cronJobs/handlers/DetachedRatingsRemovalHandler.java
+++ b/backEnd/src/main/java/dbMaintenance/cronJobs/handlers/DetachedRatingsRemovalHandler.java
@@ -1,0 +1,102 @@
+package dbMaintenance.cronJobs.handlers;
+
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
+import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
+import dbMaintenance.managers.MaintenanceDbAccessManager;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import models.User;
+import utilities.ErrorDescriptor;
+import utilities.Metrics;
+import utilities.ResultStatus;
+
+public class DetachedRatingsRemovalHandler {
+
+  private MaintenanceDbAccessManager maintenanceDbAccessManager;
+  private Metrics metrics;
+
+  public DetachedRatingsRemovalHandler(final MaintenanceDbAccessManager maintenanceDbAccessManager,
+      final Metrics metrics) {
+    this.maintenanceDbAccessManager = maintenanceDbAccessManager;
+    this.metrics = metrics;
+  }
+
+  /**
+   * Category ratings become detached when a category is deleted. We do not currently have a clean
+   * way of knowing which users have ratings for a category when deleting a category. So in light of
+   * that, we simply check all the user's ratings periodically to cleanup bad data.
+   *
+   * @return Standard result status object giving insight on whether the request was successful.
+   */
+  public ResultStatus handle() {
+    final String classMethod = "DetachedRatingsRemovalHandler.handle";
+    this.metrics.commonSetup(classMethod);
+
+    ResultStatus resultStatus = ResultStatus
+        .successful("Detached category ratings removed successfully.");
+
+    try {
+      final Iterator<Item> tableItems = this.maintenanceDbAccessManager.scanUsersTable();
+
+      while (tableItems.hasNext()) {
+        final Item userItem = tableItems.next();
+
+        try {
+          final String username = userItem.getString(User.USERNAME);
+
+          final StringBuilder updateExpressionBuilder = new StringBuilder();
+          final NameMap nameMap = new NameMap();
+
+          final Map<String, Object> oldCategoryRatingsMap = userItem.getMap(User.CATEGORY_RATINGS);
+
+          int i = 0;
+          for (final String categoryId : oldCategoryRatingsMap.keySet()) {
+            try {
+              final Item categoryItem = this.maintenanceDbAccessManager.getCategoryItem(categoryId);
+
+              if (categoryItem == null) {
+                //The category does not exist, remove it's ratings from the user item
+                final String categoryIdName = "#categoryId" + i;
+                final String dotCategoryIdName = "." + categoryIdName;
+
+                if (updateExpressionBuilder.length() == 0) {
+                  updateExpressionBuilder.append("remove ").append(User.CATEGORY_RATINGS)
+                      .append(dotCategoryIdName);
+                } else {
+                  updateExpressionBuilder.append(", ").append(User.CATEGORY_RATINGS)
+                      .append(dotCategoryIdName);
+                }
+
+                nameMap.with(categoryIdName, categoryId);
+              }
+            } catch (final Exception e) {
+              this.metrics.log(new ErrorDescriptor<>(username + " " + categoryId, classMethod, e));
+              resultStatus = ResultStatus.failure("Exception in " + classMethod);
+            }
+
+            i++;
+          }
+
+          if (updateExpressionBuilder.length() > 0) {
+            final UpdateItemSpec updateItemSpec = new UpdateItemSpec()
+                .withUpdateExpression(updateExpressionBuilder.toString())
+                .withNameMap(nameMap);
+
+            this.maintenanceDbAccessManager.updateUser(username, updateItemSpec);
+          }
+        } catch (final Exception e) {
+          this.metrics.log(new ErrorDescriptor<>(userItem.get(User.USERNAME), classMethod, e));
+          resultStatus = ResultStatus.failure("Exception in " + classMethod);
+        }
+      }
+    } catch (final Exception e) {
+      this.metrics.logWithBody(new ErrorDescriptor<>(classMethod, e));
+      resultStatus = ResultStatus.failure("Exception in " + classMethod);
+    }
+
+    this.metrics.commonClose(resultStatus.success);
+    return resultStatus;
+  }
+}

--- a/backEnd/src/main/java/dbMaintenance/managers/MaintenanceDbAccessManager.java
+++ b/backEnd/src/main/java/dbMaintenance/managers/MaintenanceDbAccessManager.java
@@ -17,4 +17,8 @@ public class MaintenanceDbAccessManager extends DbAccessManager {
   public Iterator<Item> scanGroupsTable() {
     return this.groupsTable.scan().iterator();
   }
+
+  public Iterator<Item> scanPendingEventsTable() {
+    return this.pendingEventsTable.scan().iterator();
+  }
 }

--- a/backEnd/src/main/java/dbMaintenance/modules/PocketPollMaintenanceComponent.java
+++ b/backEnd/src/main/java/dbMaintenance/modules/PocketPollMaintenanceComponent.java
@@ -3,6 +3,7 @@ package dbMaintenance.modules;
 import dbMaintenance.controllers.AddCategoryCreatorToGroupController;
 import dbMaintenance.controllers.KeyUserRatingsByVersionController;
 import dagger.Component;
+import dbMaintenance.cronJobs.controllers.DetachedRatingsRemovalController;
 import javax.inject.Singleton;
 
 @Singleton
@@ -10,4 +11,5 @@ import javax.inject.Singleton;
 public interface PocketPollMaintenanceComponent {
   void inject(KeyUserRatingsByVersionController keyUserRatingsByVersionController);
   void inject(AddCategoryCreatorToGroupController addCategoryCreatorToGroupController);
+  void inject(DetachedRatingsRemovalController detachedRatingsRemovalController);
 }

--- a/backEnd/src/main/java/dbMaintenance/modules/PocketPollMaintenanceModule.java
+++ b/backEnd/src/main/java/dbMaintenance/modules/PocketPollMaintenanceModule.java
@@ -1,5 +1,6 @@
 package dbMaintenance.modules;
 
+import dbMaintenance.cronJobs.handlers.DetachedRatingsRemovalHandler;
 import dbMaintenance.handlers.AddCategoryCreatorToGroupHandler;
 import dbMaintenance.managers.MaintenanceDbAccessManager;
 import dbMaintenance.handlers.KeyUserRatingsByVersionHandler;
@@ -31,5 +32,11 @@ public class PocketPollMaintenanceModule {
   public AddCategoryCreatorToGroupHandler provideAddCategoryCreatorToGroupHandler(
       final MaintenanceDbAccessManager maintenanceDbAccessManager) {
     return new AddCategoryCreatorToGroupHandler(maintenanceDbAccessManager, this.metrics);
+  }
+
+  @Provides
+  public DetachedRatingsRemovalHandler provideDetachedRatingsRemovalHandler(
+      final MaintenanceDbAccessManager maintenanceDbAccessManager) {
+    return new DetachedRatingsRemovalHandler(maintenanceDbAccessManager, this.metrics);
   }
 }

--- a/backEnd/src/main/java/handlers/AddPendingEventHandler.java
+++ b/backEnd/src/main/java/handlers/AddPendingEventHandler.java
@@ -1,5 +1,7 @@
 package handlers;
 
+import static utilities.Config.PENDING_EVENTS_DELIM;
+
 import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
 import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
 import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
@@ -14,7 +16,6 @@ import utilities.ResultStatus;
 
 public class AddPendingEventHandler implements ApiRequestHandler {
 
-  private static final String DELIM = ";";
   private static final String NUMBER_OF_PARTITIONS_ENV_KEY = "NUMBER_OF_PARTITIONS";
 
   private DbAccessManager dbAccessManager;
@@ -53,7 +54,7 @@ public class AddPendingEventHandler implements ApiRequestHandler {
       final String updateExpression = "set #key = :date";
       final ValueMap valueMap = new ValueMap()
           .withString(":date", expirationDate.format(this.dbAccessManager.getDateTimeFormatter()));
-      final NameMap nameMap = new NameMap().with("#key", groupId + DELIM + eventId);
+      final NameMap nameMap = new NameMap().with("#key", groupId + PENDING_EVENTS_DELIM + eventId);
 
       final UpdateItemSpec updateItemSpec = new UpdateItemSpec()
           .withUpdateExpression(updateExpression)

--- a/backEnd/src/main/java/handlers/DeleteGroupHandler.java
+++ b/backEnd/src/main/java/handlers/DeleteGroupHandler.java
@@ -1,5 +1,7 @@
 package handlers;
 
+import static utilities.Config.PENDING_EVENTS_DELIM;
+
 import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
 import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
 import com.google.common.collect.ImmutableMap;
@@ -117,7 +119,7 @@ public class DeleteGroupHandler implements ApiRequestHandler {
       final NameMap nameMap = new NameMap();
       IntStream.range(0, eventIdsList.size()).boxed()
           .forEach(i -> nameMap.with("#groupEventKey" + i,
-              deletedGroup.getGroupId() + DbAccessManager.DELIM + eventIdsList.get(i)));
+              deletedGroup.getGroupId() + PENDING_EVENTS_DELIM + eventIdsList.get(i)));
 
       final UpdateItemSpec updateItemSpec = new UpdateItemSpec()
           .withUpdateExpression(updateExpression)

--- a/backEnd/src/main/java/handlers/NewEventHandler.java
+++ b/backEnd/src/main/java/handlers/NewEventHandler.java
@@ -130,11 +130,9 @@ public class NewEventHandler implements ApiRequestHandler {
               .handle(groupId, eventId, null);
         }
 
-        //since the event could have been updated by skipping consider, we need to pull to get the most up to date event
+        //since the event could have been updated by skipping consider, we need to pull to get the
+        // most up to date event
         final Group newGroup = this.dbAccessManager.getGroupNoCache(groupId);
-//        final Group newGroup = oldGroup.clone();
-//        newGroup.getEvents().put(eventId, newEvent);
-//        newGroup.setLastActivity(lastActivity);
 
         //when rsvp is not greater than 0, updateUsersTable gets called by updateEvent
         if (newEvent.getRsvpDuration() > 0) {

--- a/backEnd/src/main/java/handlers/ScanPendingEventsHandler.java
+++ b/backEnd/src/main/java/handlers/ScanPendingEventsHandler.java
@@ -1,5 +1,7 @@
 package handlers;
 
+import static utilities.Config.PENDING_EVENTS_DELIM;
+
 import com.google.common.collect.ImmutableMap;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -16,8 +18,6 @@ import utilities.RequestFields;
 import utilities.ResultStatus;
 
 public class ScanPendingEventsHandler {
-
-  private static final String DELIM = ";";
 
   private final DbAccessManager dbAccessManager;
   private final StepFunctionManager stepFunctionManager;
@@ -62,7 +62,7 @@ public class ScanPendingEventsHandler {
                   this.dbAccessManager.getDateTimeFormatter());
 
           if (currentDate.isAfter(resolutionDate)) {
-            keyPair = Arrays.asList(key.split(DELIM));
+            keyPair = Arrays.asList(key.split(PENDING_EVENTS_DELIM));
 
             if (keyPair.size() == 2) {
               groupId = keyPair.get(0);

--- a/backEnd/src/main/java/handlers/UpdateUserChoiceRatingsHandler.java
+++ b/backEnd/src/main/java/handlers/UpdateUserChoiceRatingsHandler.java
@@ -42,7 +42,7 @@ public class UpdateUserChoiceRatingsHandler implements ApiRequestHandler {
    * @param ratings    This is the map of choice ids to user rate values
    * @param updateDb   This boolean tells the method whether or not it should update the db. If
    *                   false, this generally means the update data will be part of a transaction.
-   * @return Standard result status object giving insight on whether the request was successful
+   * @return Standard result status object giving insight on whether the request was successful.
    */
   public ResultStatus<UpdateItemData> handle(final String activeUser, final String categoryId,
       final Integer categoryVersion, final Map<String, Object> ratings, final boolean updateDb) {

--- a/backEnd/src/main/java/managers/DbAccessManager.java
+++ b/backEnd/src/main/java/managers/DbAccessManager.java
@@ -43,13 +43,12 @@ public class DbAccessManager {
   public static final String PENDING_EVENTS_PRIMARY_KEY = "ScannerId";
 
   public static final String NUMBER_OF_PARTITIONS_ENV_KEY = "NUMBER_OF_PARTITIONS";
-  public static final String DELIM = ";";
 
   //making protected for extended classes
   protected final Table groupsTable;
   protected final Table usersTable;
   private final Table categoriesTable;
-  private final Table pendingEventsTable;
+  protected final Table pendingEventsTable;
 
   private final AmazonDynamoDBClient client;
   private final DateTimeFormatter dateTimeFormatter;
@@ -180,15 +179,41 @@ public class DbAccessManager {
   }
 
   public Group getGroup(final String groupId) {
-    return new Group(this.groupsTable.getItem(new PrimaryKey(GROUPS_PRIMARY_KEY, groupId)));
+    Item groupItem;
+    if (this.cache.containsKey(groupId)) {
+      groupItem = this.cache.get(groupId);
+    } else {
+      groupItem = this.groupsTable.getItem(new PrimaryKey(GROUPS_PRIMARY_KEY, groupId));
+      this.cache.put(groupId, groupItem);
+    }
+
+    return new Group(groupItem);
   }
 
   public Group getGroupNoCache(final String groupId) {
-    return new Group(this.groupsTable.getItem(new PrimaryKey(GROUPS_PRIMARY_KEY, groupId)));
+    final Item groupItem = this.groupsTable.getItem(new PrimaryKey(GROUPS_PRIMARY_KEY, groupId));
+    this.cache.put(groupId, groupItem);
+
+    return new Group(groupItem);
   }
 
   public Item getGroupItem(final String groupId) {
-    return this.groupsTable.getItem(new PrimaryKey(GROUPS_PRIMARY_KEY, groupId));
+    Item groupItem;
+    if (this.cache.containsKey(groupId)) {
+      groupItem = this.cache.get(groupId);
+    } else {
+      groupItem = this.groupsTable.getItem(new PrimaryKey(GROUPS_PRIMARY_KEY, groupId));
+      this.cache.put(groupId, groupItem);
+    }
+
+    return groupItem;
+  }
+
+  public Item getGroupItemNoCache(final String groupId) {
+    final Item groupItem = this.groupsTable.getItem(new PrimaryKey(GROUPS_PRIMARY_KEY, groupId));
+    this.cache.put(groupId, groupItem);
+
+    return groupItem;
   }
 
   public UpdateItemOutcome updateGroup(final String groupId,

--- a/backEnd/src/main/java/models/UserRatings.java
+++ b/backEnd/src/main/java/models/UserRatings.java
@@ -2,6 +2,7 @@ package models;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import lombok.Data;
 
 @Data
@@ -24,6 +25,10 @@ public class UserRatings {
       modelAsMap.putIfAbsent(versionRatingsEntry.getKey(), versionRatingsEntry.getValue());
     }
     return modelAsMap;
+  }
+
+  public Set<String> getVersionSet() {
+    return this.versionsToRatingMaps.keySet();
   }
 
   public Map<String, Integer> getRatings(final String version) {

--- a/backEnd/src/main/java/utilities/Config.java
+++ b/backEnd/src/main/java/utilities/Config.java
@@ -11,4 +11,5 @@ public class Config {
   //validation parameters used across more than one handler
   public static final Integer MAX_DURATION = 10000;
   public static final Integer MAX_GROUP_MEMBERS = 300;
+  public static final String PENDING_EVENTS_DELIM = ";";
 }


### PR DESCRIPTION
## Summary
I added these files into the db maintenance directory as that's what they're effectively doing. It's a scan of the database that updates the broken pieces. I run updates per user so as to not have more updates than necessary.

I considered having a monthly handler/timebased handler that runs all actions that execute on that time basis but I decided that was necessary for the first cron job and if we find ourselves adding a bunch of jobs with the same frequency then we can address that then.

I added a new Lambda function for this action and set up the cloud watch rule to run with a frequency of 1 execution/30 days.

## Testing
I set the could watch rule to run every minute and I checked the db/logs to ensure that everything was working as intended. Then I set the frequency back to the appropriate one (aka 1 per 30 days and no per minute).