### PR TITLE
Choices Overhaul

### DIFF
--- a/backEnd/src/main/java/handlers/UpdateUserSettingsHandler.java
+++ b/backEnd/src/main/java/handlers/UpdateUserSettingsHandler.java
@@ -166,7 +166,7 @@ public class UpdateUserSettingsHandler implements ApiRequestHandler {
         this.updateActiveUsersFavorites(newFavorites, oldUser.getFavorites().keySet(), activeUser);
 
         final UserForApiResponse updatedUser = new UserForApiResponse(
-            this.dbAccessManager.getUserItem(activeUser));
+            this.dbAccessManager.getUserNoCache(activeUser));
         resultStatus = ResultStatus.successful(JsonUtils.convertObjectToJson(updatedUser.asMap()));
       } else {
         metrics.logWithBody(new WarningDescriptor<>(classMethod, errorMessage.get()));

--- a/front_end_pocket_poll/lib/about_widgets/about_descriptions.dart
+++ b/front_end_pocket_poll/lib/about_widgets/about_descriptions.dart
@@ -31,7 +31,6 @@ class AboutDescriptions {
       <p>Categories themselves are independent entities. They must be “attached” to a group in order to be used in events. This is done by going to the group settings page and adding any of the categories that you own.</p>
       <p>When your friends add categories to a group you are in you can edit your ratings for their choices from the group settings page. E.g. If Bob has ‘Coffee Shops’ as a choice you can go in and set your rating so your opinion is leveraged anytime that category is used for an event.</p>
       <p>Categories owned by you or your friends can be copied. When copied you gain ownership of the new category and can add or remove as many choices as you please.</p>
-      <p>Categories can change and this is tracked by a category's version. When an event is created it takes a snapshot of the selected category, so check the version number to know if you need to update your ratings.</p>
     """);
 
   static Html groups = Html(data: """

--- a/front_end_pocket_poll/lib/categories_widgets/categories_list.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/categories_list.dart
@@ -3,6 +3,7 @@ import 'package:front_end_pocket_poll/imports/categories_manager.dart';
 import 'package:front_end_pocket_poll/imports/globals.dart';
 import 'package:front_end_pocket_poll/imports/result_status.dart';
 import 'package:front_end_pocket_poll/models/category.dart';
+import 'package:front_end_pocket_poll/utilities/sorter.dart';
 import 'package:front_end_pocket_poll/utilities/utilities.dart';
 import 'categories_list_item.dart';
 
@@ -38,9 +39,9 @@ class _CategoryListState extends State<CategoryList> {
               itemCount: widget.categories.length,
               itemBuilder: (BuildContext context, int index) {
                 if (widget.sortType == Globals.alphabeticalSort) {
-                  CategoriesManager.sortByAlphaAscending(widget.categories);
+                  Sorter.sortCategoriesByAlphaAscending(widget.categories);
                 } else {
-                  CategoriesManager.sortByAlphaDescending(widget.categories);
+                  Sorter.sortCategoriesByAlphaDescending(widget.categories);
                 }
                 return CategoriesListItem(
                   widget.categories[index],

--- a/front_end_pocket_poll/lib/categories_widgets/category_create.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_create.dart
@@ -8,6 +8,7 @@ import 'package:front_end_pocket_poll/imports/globals.dart';
 import 'package:front_end_pocket_poll/imports/result_status.dart';
 import 'package:front_end_pocket_poll/models/category.dart';
 import 'package:front_end_pocket_poll/models/category_rating_tuple.dart';
+import 'package:front_end_pocket_poll/utilities/sorter.dart';
 import 'package:front_end_pocket_poll/utilities/utilities.dart';
 import 'package:front_end_pocket_poll/utilities/validator.dart';
 
@@ -26,6 +27,7 @@ class _CategoryCreateState extends State<CategoryCreate> {
   final ScrollController scrollController = new ScrollController();
 
   int nextChoiceValue;
+  int sortVal;
   bool autoValidate;
 
   @override
@@ -48,11 +50,12 @@ class _CategoryCreateState extends State<CategoryCreate> {
     initRatingController.text = Globals.defaultChoiceRating.toString();
 
     this.nextChoiceValue = 1;
+    this.sortVal = Globals.alphabeticalSort;
 
     ChoiceRow choice = new ChoiceRow(
         0, true, initLabelController, initRatingController,
         focusNode: new FocusNode(),
-        key: Key("0"),
+        key: UniqueKey(),
         displayLabelHelpText: false,
         displayRateHelpText: false,
         deleteChoice: (choice) => deleteChoice(choice));
@@ -104,27 +107,101 @@ class _CategoryCreateState extends State<CategoryCreate> {
                         padding: EdgeInsets.all(
                             MediaQuery.of(context).size.height * .008),
                       ),
-                      Container(
-                        width: MediaQuery.of(context).size.width * .7,
-                        child: TextFormField(
-                          maxLength: Globals.maxCategoryNameLength,
-                          validator: validCategoryName,
-                          key: Key("category_create:category_name_input"),
-                          controller: this.categoryNameController,
-                          textCapitalization: TextCapitalization.sentences,
-                          style: TextStyle(fontSize: 20),
-                          textInputAction: TextInputAction.next,
-                          onFieldSubmitted: (val) {
-                            // on enter, move focus to the first choice row
-                            if (this.choiceRows.isNotEmpty) {
-                              this.choiceRows[0].requestFocus(context);
-                            }
-                          },
-                          decoration: InputDecoration(
-                              border: OutlineInputBorder(),
-                              labelText: "Category Name",
-                              counterText: ""),
-                        ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Container(
+                            width: MediaQuery.of(context).size.width * .7,
+                            child: TextFormField(
+                              maxLength: Globals.maxCategoryNameLength,
+                              validator: validCategoryName,
+                              key: Key("category_create:category_name_input"),
+                              controller: this.categoryNameController,
+                              textCapitalization: TextCapitalization.sentences,
+                              style: TextStyle(fontSize: 20),
+                              textInputAction: TextInputAction.next,
+                              onFieldSubmitted: (val) {
+                                // on enter, move focus to the first choice row
+                                if (this.choiceRows.isNotEmpty) {
+                                  this.choiceRows[0].requestFocus(context);
+                                }
+                              },
+                              decoration: InputDecoration(
+                                  border: OutlineInputBorder(),
+                                  labelText: "Category Name",
+                                  counterText: ""),
+                            ),
+                          ),
+                          PopupMenuButton<int>(
+                            child: Icon(
+                              Icons.sort,
+                              size: MediaQuery.of(context).size.height * .04,
+                            ),
+                            key: Key("category_create:sort_button"),
+                            tooltip: "Sort Choices",
+                            onSelected: (int result) {
+                              if (this.sortVal != result) {
+                                hideKeyboard(context);
+                                // prevents useless updates if sort didn't change
+                                this.sortVal = result;
+                                setState(() {
+                                  // VERY IMPORTANT. Cannot rebuild rows otherwise original order is messed up
+                                  Sorter.sortChoiceRows(
+                                      this.choiceRows, this.sortVal);
+                                });
+                              }
+                            },
+                            itemBuilder: (BuildContext context) =>
+                                <PopupMenuEntry<int>>[
+                              PopupMenuItem<int>(
+                                value: Globals.alphabeticalSort,
+                                child: Text(
+                                  Globals.alphabeticalSortString,
+                                  style: TextStyle(
+                                      // if it is selected, underline it
+                                      decoration: (this.sortVal ==
+                                              Globals.alphabeticalSort)
+                                          ? TextDecoration.underline
+                                          : null),
+                                ),
+                              ),
+                              PopupMenuItem<int>(
+                                value: Globals.alphabeticalReverseSort,
+                                child: Text(
+                                    Globals.alphabeticalReverseSortString,
+                                    style: TextStyle(
+                                        // if it is selected, underline it
+                                        decoration: (this.sortVal ==
+                                                Globals.alphabeticalReverseSort)
+                                            ? TextDecoration.underline
+                                            : null)),
+                              ),
+                              PopupMenuItem<int>(
+                                value: Globals.choiceRatingAscending,
+                                child: Text(
+                                    Globals.choiceRatingAscendingSortString,
+                                    style: TextStyle(
+                                        // if it is selected, underline it
+                                        decoration: (this.sortVal ==
+                                                Globals.choiceRatingAscending)
+                                            ? TextDecoration.underline
+                                            : null)),
+                              ),
+                              PopupMenuItem<int>(
+                                value: Globals.choiceRatingDescending,
+                                child: Text(
+                                  Globals.choiceRatingDescendingSortString,
+                                  style: TextStyle(
+                                      // if it is selected, underline it
+                                      decoration: (this.sortVal ==
+                                              Globals.choiceRatingDescending)
+                                          ? TextDecoration.underline
+                                          : null),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
                       ),
                       Padding(
                         padding: EdgeInsets.all(
@@ -282,6 +359,7 @@ class _CategoryCreateState extends State<CategoryCreate> {
         });
       } else {
         showLoadingDialog(this.context, "Creating category...", true);
+        // TODO need to add sort value in request
         ResultStatus<Category> resultStatus =
             await CategoriesManager.addOrEditCategory(
                 this.categoryNameController.text.trim(),

--- a/front_end_pocket_poll/lib/categories_widgets/category_create.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_create.dart
@@ -44,7 +44,7 @@ class _CategoryCreateState extends State<CategoryCreate> {
   @override
   void initState() {
     this.autoValidate = false;
-    // we are creating a category, so thus the first choice value is already set to 1
+    // we are creating a category, so thus the first choice value is already set to 0
     TextEditingController initLabelController = new TextEditingController();
     TextEditingController initRatingController = new TextEditingController();
     initRatingController.text = Globals.defaultChoiceRating.toString();
@@ -145,7 +145,6 @@ class _CategoryCreateState extends State<CategoryCreate> {
                                 // prevents useless updates if sort didn't change
                                 this.sortVal = result;
                                 setState(() {
-                                  // VERY IMPORTANT. Cannot rebuild rows otherwise original order is messed up
                                   Sorter.sortChoiceRows(
                                       this.choiceRows, this.sortVal);
                                 });

--- a/front_end_pocket_poll/lib/categories_widgets/category_create.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_create.dart
@@ -53,6 +53,9 @@ class _CategoryCreateState extends State<CategoryCreate> {
     ChoiceRow choice = new ChoiceRow(
         0, true, initLabelController, initRatingController,
         focusNode: new FocusNode(),
+        key: Key(0.toString()),
+        displayLabelHelpText: false,
+        displayRateHelpText: false,
         deleteChoice: (choice) => deleteChoice(choice));
     this.choiceRows.add(choice); // provide an initial choice to edit
     super.initState();
@@ -169,26 +172,29 @@ class _CategoryCreateState extends State<CategoryCreate> {
                   labelController,
                   rateController,
                   deleteChoice: (choice) => deleteChoice(choice),
+                  displayLabelHelpText: false,
+                  displayRateHelpText: false,
+                  key: Key(this.nextChoiceValue.toString()),
                   focusNode: focusNode,
                 );
                 setState(() {
-                  this.choiceRows.add(choice);
+                  this.choiceRows.insert(0, choice);
                   this.nextChoiceValue++;
                 });
                 SchedulerBinding.instance
-                    .addPostFrameCallback((_) => scrollToBottom(choice));
+                    .addPostFrameCallback((_) => scrollToTop(choice));
               },
             )),
       ),
     );
   }
 
-  // scrolls to the bottom of the listview of all the choices
-  void scrollToBottom(ChoiceRow choiceRow) async {
+  // scrolls to the top of the listview of all the choices
+  void scrollToTop(ChoiceRow choiceRow) async {
     await this
         .scrollController
         .animateTo(
-          this.scrollController.position.maxScrollExtent,
+          0,
           duration: const Duration(microseconds: 100),
           curve: Curves.easeOut,
         )

--- a/front_end_pocket_poll/lib/categories_widgets/category_create.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_create.dart
@@ -53,7 +53,7 @@ class _CategoryCreateState extends State<CategoryCreate> {
     ChoiceRow choice = new ChoiceRow(
         0, true, initLabelController, initRatingController,
         focusNode: new FocusNode(),
-        key: Key(0.toString()),
+        key: Key("0"),
         displayLabelHelpText: false,
         displayRateHelpText: false,
         deleteChoice: (choice) => deleteChoice(choice));
@@ -114,6 +114,7 @@ class _CategoryCreateState extends State<CategoryCreate> {
                           controller: this.categoryNameController,
                           textCapitalization: TextCapitalization.sentences,
                           style: TextStyle(fontSize: 20),
+                          textInputAction: TextInputAction.next,
                           onFieldSubmitted: (val) {
                             // on enter, move focus to the first choice row
                             if (this.choiceRows.isNotEmpty) {
@@ -132,18 +133,13 @@ class _CategoryCreateState extends State<CategoryCreate> {
                       ),
                       Expanded(
                         child: Scrollbar(
-                          child: CustomScrollView(
-                            shrinkWrap: false,
-                            controller: this.scrollController,
-                            slivers: <Widget>[
-                              SliverList(
-                                  delegate: SliverChildBuilderDelegate(
-                                      (context, index) =>
-                                          this.choiceRows[index],
-                                      childCount: this.choiceRows.length),
-                                  key: Key("category_create:choice_list"))
-                            ],
-                          ),
+                          child: ListView.builder(
+                              shrinkWrap: false,
+                              controller: this.scrollController,
+                              itemCount: this.choiceRows.length,
+                              itemBuilder: (context, index) =>
+                                  this.choiceRows[index],
+                              key: Key("category_create:choice_list")),
                         ),
                       ),
                       Padding(
@@ -174,11 +170,11 @@ class _CategoryCreateState extends State<CategoryCreate> {
                   deleteChoice: (choice) => deleteChoice(choice),
                   displayLabelHelpText: false,
                   displayRateHelpText: false,
-                  key: Key(this.nextChoiceValue.toString()),
+                  key: UniqueKey(),
                   focusNode: focusNode,
                 );
+                this.choiceRows.insert(0, choice);
                 setState(() {
-                  this.choiceRows.insert(0, choice);
                   this.nextChoiceValue++;
                 });
                 SchedulerBinding.instance

--- a/front_end_pocket_poll/lib/categories_widgets/category_create.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_create.dart
@@ -22,7 +22,6 @@ class _CategoryCreateState extends State<CategoryCreate> {
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
   final TextEditingController categoryNameController =
       new TextEditingController();
-  final int defaultRate = 3;
   final List<ChoiceRow> choiceRows = new List<ChoiceRow>();
   final ScrollController scrollController = new ScrollController();
 
@@ -46,7 +45,7 @@ class _CategoryCreateState extends State<CategoryCreate> {
     // we are creating a category, so thus the first choice value is already set to 1
     TextEditingController initLabelController = new TextEditingController();
     TextEditingController initRatingController = new TextEditingController();
-    initRatingController.text = this.defaultRate.toString();
+    initRatingController.text = Globals.defaultChoiceRating.toString();
 
     this.nextChoiceValue = 1;
 
@@ -160,7 +159,7 @@ class _CategoryCreateState extends State<CategoryCreate> {
                     new TextEditingController();
                 TextEditingController rateController =
                     new TextEditingController();
-                rateController.text = this.defaultRate.toString();
+                rateController.text = Globals.defaultChoiceRating.toString();
 
                 ChoiceRow choice = new ChoiceRow(
                   this.nextChoiceValue,

--- a/front_end_pocket_poll/lib/categories_widgets/category_edit.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_edit.dart
@@ -69,7 +69,7 @@ class _CategoryEditState extends State<CategoryEdit> {
     this.loading = true;
     this.errorLoading = false;
     this.sortVal =
-        Globals.defaultChoiceSort; // TODO use value from user settings
+        Globals.alphabeticalSort; // TODO use value from user settings
 
     if (widget.categoryRatingTuple != null) {
       // means we are editing from the group category page
@@ -218,18 +218,6 @@ class _CategoryEditState extends State<CategoryEdit> {
                                     },
                                     itemBuilder: (BuildContext context) =>
                                         <PopupMenuEntry<int>>[
-                                      PopupMenuItem<int>(
-                                        value: Globals.defaultChoiceSort,
-                                        child: Text(
-                                          Globals.defaultChoiceSortString,
-                                          style: TextStyle(
-                                              // if it is selected, underline it
-                                              decoration: (this.sortVal ==
-                                                      Globals.defaultChoiceSort)
-                                                  ? TextDecoration.underline
-                                                  : null),
-                                        ),
-                                      ),
                                       PopupMenuItem<int>(
                                         value: Globals.alphabeticalSort,
                                         child: Text(

--- a/front_end_pocket_poll/lib/categories_widgets/category_edit.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_edit.dart
@@ -32,13 +32,12 @@ class _CategoryEditState extends State<CategoryEdit> {
       new TextEditingController();
   final List<ChoiceRow> choiceRows = new List<ChoiceRow>();
   final ScrollController scrollController = new ScrollController();
-  final int defaultRate = 3;
 
   Map<String, int>
       originalLabels; // for copying purposes and detecting if changes were made
   Map<String, String>
       originalRatings; // used if the user is not owner of the category
-  Map<String, String> unratedChoices;
+  Map<String, bool> unratedChoices;
   bool autoValidate;
   bool isCategoryOwner;
   bool loading;
@@ -64,7 +63,7 @@ class _CategoryEditState extends State<CategoryEdit> {
   void initState() {
     this.originalLabels = new LinkedHashMap<String, int>();
     this.originalRatings = new LinkedHashMap<String, String>();
-    this.unratedChoices = new LinkedHashMap<String, String>();
+    this.unratedChoices = new LinkedHashMap<String, bool>();
     this.autoValidate = false;
     this.categoryChanged = false;
     this.loading = true;
@@ -346,7 +345,8 @@ class _CategoryEditState extends State<CategoryEdit> {
                           new TextEditingController();
                       TextEditingController rateController =
                           new TextEditingController();
-                      rateController.text = this.defaultRate.toString();
+                      rateController.text =
+                          Globals.defaultChoiceRating.toString();
 
                       ChoiceRow choiceRow = new ChoiceRow(
                         this.nextChoiceNum,
@@ -463,7 +463,8 @@ class _CategoryEditState extends State<CategoryEdit> {
   void updateUnratedChoices() {
     Map<String, String> ratesToSave = new LinkedHashMap<String, String>();
     for (String choiceLabel in this.unratedChoices.keys) {
-      ratesToSave.putIfAbsent(choiceLabel, () => this.defaultRate.toString());
+      ratesToSave.putIfAbsent(
+          choiceLabel, () => Globals.defaultChoiceRating.toString());
     }
     UsersManager.updateUserChoiceRatings(this.category.categoryId, ratesToSave);
   }
@@ -626,16 +627,15 @@ class _CategoryEditState extends State<CategoryEdit> {
       labelController.text = choiceLabel;
       // we assume the user has no ratings so put all ratings to default value
       TextEditingController rateController = new TextEditingController();
-      rateController.text = this.defaultRate.toString();
+      rateController.text = Globals.defaultChoiceRating.toString();
 
       //check to see if the above assumption of having no ratings was true
       if (this.originalRatings != null &&
           this.originalRatings.containsKey(choiceLabel)) {
         rateController.text = this.originalRatings[choiceLabel];
       } else {
-        this
-            .unratedChoices
-            .putIfAbsent(choiceLabel, () => this.defaultRate.toString());
+        // "true" because user hasn't indicated that they've acknowledged the choice
+        this.unratedChoices.putIfAbsent(choiceLabel, () => true);
       }
       ChoiceRow choice = new ChoiceRow(
         this.category.choices[choiceLabel],

--- a/front_end_pocket_poll/lib/categories_widgets/category_edit.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_edit.dart
@@ -1,5 +1,4 @@
 import 'dart:collection';
-import 'dart:math';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -33,11 +32,9 @@ class _CategoryEditState extends State<CategoryEdit> {
   final List<ChoiceRow> choiceRows = new List<ChoiceRow>();
   final ScrollController scrollController = new ScrollController();
 
-  Map<String, int>
-      originalLabels; // for copying purposes and detecting if changes were made
-  Map<String, String>
-      originalRatings; // used if the user is not owner of the category
-  Map<String, bool> unratedChoices;
+  Map<String, int> originalLabels; // for copying and detecting changes
+  Map<String, String> originalRatings;
+  Map<String, bool> unratedChoices; // used if user not owner of the category
   bool autoValidate;
   bool isCategoryOwner;
   bool loading;
@@ -210,7 +207,6 @@ class _CategoryEditState extends State<CategoryEdit> {
                                         // prevents useless updates if sort didn't change
                                         this.sortVal = result;
                                         setState(() {
-                                          // VERY IMPORTANT. Cannot rebuild rows otherwise original order is messed up
                                           Sorter.sortChoiceRows(
                                               this.choiceRows, this.sortVal);
                                         });
@@ -349,7 +345,7 @@ class _CategoryEditState extends State<CategoryEdit> {
                         key: UniqueKey(),
                         isNewChoice: true,
                         originalLabel: "",
-                        originalRating: "3",
+                        originalRating: Globals.defaultChoiceRating.toString(),
                       );
                       this.choiceRows.insert(0, choiceRow);
                       setState(() {
@@ -608,8 +604,6 @@ class _CategoryEditState extends State<CategoryEdit> {
     this.isCategoryOwner = (this.category.owner == Globals.username);
     this.categoryNameController.text = this.category.categoryName;
 
-    int i = 0;
-
     for (String choiceLabel in this.category.choices.keys) {
       TextEditingController labelController = new TextEditingController();
       labelController.text = choiceLabel;
@@ -637,13 +631,12 @@ class _CategoryEditState extends State<CategoryEdit> {
         displayLabelHelpText: this.isCategoryOwner,
         displayRateHelpText: !this.isCategoryOwner,
         isNewChoice: false,
-        unratedChoices: unratedChoices,
+        unratedChoices: this.unratedChoices,
         key: UniqueKey(),
       );
       this.choiceRows.add(choice);
-      i++;
     }
-    this.nextChoiceNum = i;
+    this.nextChoiceNum = this.choiceRows.length;
 
     // sort by rows by choice number
     Sorter.sortChoiceRows(this.choiceRows, this.sortVal);

--- a/front_end_pocket_poll/lib/categories_widgets/choice_row.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/choice_row.dart
@@ -17,7 +17,7 @@ class ChoiceRow extends StatefulWidget {
   final bool isNewChoice;
   final bool displayLabelHelpText;
   final bool displayRateHelpText;
-  final Map<String, bool> unratedChoices; // only used if not the owner
+  final Map<String, bool> unratedChoices; // used if not the owner of category
 
   ChoiceRow(this.choiceNumber, this.isOwner, this.labelController,
       this.rateController,
@@ -45,7 +45,7 @@ class ChoiceRow extends StatefulWidget {
 class _ChoiceRowState extends State<ChoiceRow> {
   FocusNode ratingsFocus;
   int rating;
-  bool changed;
+  bool choiceChanged;
   bool choiceNotRated;
   String labelHelpText;
   final String ratingRegex =
@@ -53,27 +53,26 @@ class _ChoiceRowState extends State<ChoiceRow> {
 
   @override
   void initState() {
-    this.changed = false;
-    // used in editing a category as the owner
+    this.choiceChanged = false;
     if (widget.displayLabelHelpText) {
+      // used if the owner is editing a category
+      this.labelHelpText = " ";
       if (widget.isNewChoice) {
         this.labelHelpText = "(New)";
       } else {
         this.labelHelpText = "(Modified)";
       }
-    } else {
-      // if you aren't the owner, you shouldn't ever get text underneath the label text input
-      this.labelHelpText = " ";
     }
 
-    // used for when updating ratings from an event
+    // used for when updating ratings
     if (widget.displayRateHelpText) {
       this.labelHelpText = "(Modified)";
     }
+
     // do this check since choice row can get destroyed at any point, if destroyed still want to show if new/modified
     if (widget.labelController.text.toString() != widget.originalLabel ||
         widget.rateController.text.toString() != widget.originalRating) {
-      this.changed = true;
+      this.choiceChanged = true;
     }
 
     if (widget.unratedChoices != null &&
@@ -117,11 +116,11 @@ class _ChoiceRowState extends State<ChoiceRow> {
               widget.checkForChange();
               if (val == widget.originalLabel) {
                 setState(() {
-                  this.changed = false;
+                  this.choiceChanged = false;
                 });
               } else {
                 setState(() {
-                  this.changed = true;
+                  this.choiceChanged = true;
                 });
               }
             },
@@ -136,7 +135,7 @@ class _ChoiceRowState extends State<ChoiceRow> {
                 labelStyle: TextStyle(fontSize: 15),
                 labelText: "Choice",
                 counterText: "",
-                helperText: (widget.displayLabelHelpText && this.changed)
+                helperText: (widget.displayLabelHelpText && this.choiceChanged)
                     ? this.labelHelpText
                     : " "),
             key: Key("choice_row:choice_name_input:${widget.choiceNumber}"),
@@ -158,13 +157,14 @@ class _ChoiceRowState extends State<ChoiceRow> {
                 hideKeyboard(context);
                 widget.checkForChange();
               }
+              // detect whether label text should be shown
               if (this.rating.toString() == widget.originalRating) {
                 setState(() {
-                  this.changed = false;
+                  this.choiceChanged = false;
                 });
               } else {
                 setState(() {
-                  this.changed = true;
+                  this.choiceChanged = true;
                 });
               }
             },
@@ -193,7 +193,7 @@ class _ChoiceRowState extends State<ChoiceRow> {
                 labelText:
                     "Rating (${Globals.minChoiceRating}-${Globals.maxChoiceRating})",
                 counterText: "",
-                helperText: (widget.displayRateHelpText && this.changed)
+                helperText: (widget.displayRateHelpText && this.choiceChanged)
                     ? this.labelHelpText
                     : " "),
           ),

--- a/front_end_pocket_poll/lib/categories_widgets/choice_row.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/choice_row.dart
@@ -106,8 +106,10 @@ class _ChoiceRowState extends State<ChoiceRow> {
           child: TextFormField(
             onTap: () {
               setState(() {
-                widget.unratedChoices
-                    .update(widget.originalLabel, (_) => false);
+                if (widget.unratedChoices.containsKey(widget.originalLabel)) {
+                  widget.unratedChoices
+                      .update(widget.originalLabel, (_) => false);
+                }
                 this.choiceNotRated = false;
               });
             },
@@ -168,8 +170,10 @@ class _ChoiceRowState extends State<ChoiceRow> {
             },
             onTap: () {
               setState(() {
-                widget.unratedChoices
-                    .update(widget.originalLabel, (_) => false);
+                if (widget.unratedChoices.containsKey(widget.originalLabel)) {
+                  widget.unratedChoices
+                      .update(widget.originalLabel, (_) => false);
+                }
                 this.choiceNotRated = false;
               });
             },
@@ -217,8 +221,10 @@ class _ChoiceRowState extends State<ChoiceRow> {
             key: Key("choice_row:new_choice_button:${widget.choiceNumber}"),
             onPressed: () {
               setState(() {
-                widget.unratedChoices
-                    .update(widget.originalLabel, (_) => false);
+                if (widget.unratedChoices.containsKey(widget.originalLabel)) {
+                  widget.unratedChoices
+                      .update(widget.originalLabel, (_) => false);
+                }
                 this.choiceNotRated = false;
               });
             },

--- a/front_end_pocket_poll/lib/categories_widgets/choice_row.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/choice_row.dart
@@ -17,7 +17,7 @@ class ChoiceRow extends StatefulWidget {
   final bool isNewChoice;
   final bool displayLabelHelpText;
   final bool displayRateHelpText;
-  final Map<String, String> unratedChoices; // only used if not the owner
+  final Map<String, bool> unratedChoices; // only used if not the owner
 
   ChoiceRow(this.choiceNumber, this.isOwner, this.labelController,
       this.rateController,
@@ -53,7 +53,6 @@ class _ChoiceRowState extends State<ChoiceRow> {
 
   @override
   void initState() {
-    print(widget.key.toString() + widget.choiceNumber.toString() + widget.focusNode.toString());
     this.changed = false;
     // used in editing a category as the owner
     if (widget.displayLabelHelpText) {
@@ -78,7 +77,9 @@ class _ChoiceRowState extends State<ChoiceRow> {
     }
 
     if (widget.unratedChoices != null &&
-        widget.unratedChoices.containsKey(widget.originalLabel)) {
+        widget.unratedChoices.containsKey(widget.originalLabel) &&
+        widget.unratedChoices[widget.originalLabel]) {
+      // only show alert icon if user hasn't acknowledged the new choices
       this.choiceNotRated = true;
     } else {
       this.choiceNotRated = false;
@@ -105,6 +106,8 @@ class _ChoiceRowState extends State<ChoiceRow> {
           child: TextFormField(
             onTap: () {
               setState(() {
+                widget.unratedChoices
+                    .update(widget.originalLabel, (_) => false);
                 this.choiceNotRated = false;
               });
             },
@@ -165,6 +168,8 @@ class _ChoiceRowState extends State<ChoiceRow> {
             },
             onTap: () {
               setState(() {
+                widget.unratedChoices
+                    .update(widget.originalLabel, (_) => false);
                 this.choiceNotRated = false;
               });
             },
@@ -212,6 +217,8 @@ class _ChoiceRowState extends State<ChoiceRow> {
             key: Key("choice_row:new_choice_button:${widget.choiceNumber}"),
             onPressed: () {
               setState(() {
+                widget.unratedChoices
+                    .update(widget.originalLabel, (_) => false);
                 this.choiceNotRated = false;
               });
             },

--- a/front_end_pocket_poll/lib/categories_widgets/choice_row.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/choice_row.dart
@@ -59,6 +59,7 @@ class _ChoiceRowState extends State<ChoiceRow> {
         this.labelHelpText = "(Modified)";
       }
     } else {
+      // if you aren't the owner, you shouldn't ever get text underneath the label text input
       this.labelHelpText = " ";
     }
 

--- a/front_end_pocket_poll/lib/events_widgets/event_details_consider.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_details_consider.dart
@@ -291,6 +291,8 @@ class _EventDetailsConsiderState extends State<EventDetailsConsider> {
       Globals.currentGroupResponse.group.events[widget.eventId].optedIn
           .putIfAbsent(
               Globals.username, () => new Member.fromUser(Globals.user));
+      this.event.optedIn.putIfAbsent(
+          Globals.username, () => new Member.fromUser(Globals.user));
       this.userRows.putIfAbsent(
           Globals.username,
           () => EventUserRow(
@@ -298,6 +300,7 @@ class _EventDetailsConsiderState extends State<EventDetailsConsider> {
     } else {
       Globals.currentGroupResponse.group.events[widget.eventId].optedIn
           .remove(Globals.username);
+      this.event.optedIn.remove(Globals.username);
       this.userRows.remove(Globals.username);
     }
     setState(() {});

--- a/front_end_pocket_poll/lib/events_widgets/event_update_ratings.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_update_ratings.dart
@@ -55,7 +55,7 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
     this.ratingsChanged = false;
     this.loading = true;
     this.errorLoading = false;
-    this.sortVal = Globals.defaultChoiceSort; // TODO get from user object
+    this.sortVal = Globals.alphabeticalSort; // TODO get from user object
     getCategory();
     super.initState();
   }
@@ -163,18 +163,6 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
                                 },
                                 itemBuilder: (BuildContext context) =>
                                     <PopupMenuEntry<int>>[
-                                  PopupMenuItem<int>(
-                                    value: Globals.defaultChoiceSort,
-                                    child: Text(
-                                      Globals.defaultChoiceSortString,
-                                      style: TextStyle(
-                                          // if it is selected, underline it
-                                          decoration: (this.sortVal ==
-                                                  Globals.defaultChoiceSort)
-                                              ? TextDecoration.underline
-                                              : null),
-                                    ),
-                                  ),
                                   PopupMenuItem<int>(
                                     value: Globals.alphabeticalSort,
                                     child: Text(

--- a/front_end_pocket_poll/lib/events_widgets/event_update_ratings.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_update_ratings.dart
@@ -1,5 +1,4 @@
 import 'dart:collection';
-import 'dart:math';
 
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
@@ -155,7 +154,6 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
                                     // prevents useless updates if sort didn't change
                                     this.sortVal = result;
                                     setState(() {
-                                      // VERY IMPORTANT. Cannot rebuild rows otherwise original order is messed up
                                       Sorter.sortChoiceRows(
                                           this.choiceRows, this.sortVal);
                                     });
@@ -427,7 +425,6 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
         this.unratedChoices.putIfAbsent(choiceLabel, () => true);
       }
 
-      // TODO put map of choices that don't have rating in this constructor
       ChoiceRow choice = new ChoiceRow(
         this.category.choices[choiceLabel],
         false,
@@ -439,7 +436,7 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
         displayLabelHelpText: false,
         isNewChoice: false,
         checkForChange: checkForChanges,
-        unratedChoices: unratedChoices,
+        unratedChoices: this.unratedChoices,
         key: UniqueKey(),
       );
       this.choiceRows.add(choice);

--- a/front_end_pocket_poll/lib/events_widgets/event_update_ratings.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_update_ratings.dart
@@ -329,6 +329,8 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
         false,
         labelController,
         rateController,
+        displayRateHelpText: true,
+        displayLabelHelpText: false,
         checkForChange: checkForChanges,
       );
       this.choiceRows.add(choice);

--- a/front_end_pocket_poll/lib/events_widgets/event_update_ratings.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_update_ratings.dart
@@ -27,10 +27,9 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
   final List<ChoiceRow> choiceRows = new List<ChoiceRow>();
   final TextEditingController categoryNameController =
       new TextEditingController();
-  final int defaultRate = 3;
 
   Map<String, String> originalRatings;
-  Map<String, String> unratedChoices;
+  Map<String, bool> unratedChoices;
   bool isCategoryOwner;
   bool loading;
   bool errorLoading;
@@ -46,14 +45,13 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
       choiceRow.rateController.dispose();
       choiceRow.labelController.dispose();
     }
-    // TODO send to backend the ratings as a blind send
     super.dispose();
   }
 
   @override
   void initState() {
     this.originalRatings = new LinkedHashMap<String, String>();
-    this.unratedChoices = new LinkedHashMap<String, String>();
+    this.unratedChoices = new LinkedHashMap<String, bool>();
     this.ratingsChanged = false;
     this.loading = true;
     this.errorLoading = false;
@@ -349,7 +347,8 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
   void updateUnratedChoices() {
     Map<String, String> ratesToSave = new LinkedHashMap<String, String>();
     for (String choiceLabel in this.unratedChoices.keys) {
-      ratesToSave.putIfAbsent(choiceLabel, () => this.defaultRate.toString());
+      ratesToSave.putIfAbsent(
+          choiceLabel, () => Globals.defaultChoiceRating.toString());
     }
     UsersManager.updateUserChoiceRatings(this.category.categoryId, ratesToSave);
   }
@@ -429,16 +428,15 @@ class _EventUpdateRatingsState extends State<EventUpdateRatings> {
       labelController.text = choiceLabel;
       // we assume the user has no ratings so put all ratings to default value
       TextEditingController rateController = new TextEditingController();
-      rateController.text = this.defaultRate.toString();
+      rateController.text = Globals.defaultChoiceRating.toString();
 
       //check to see if the above assumption of having no ratings was true
       if (this.originalRatings != null &&
           this.originalRatings.containsKey(choiceLabel)) {
         rateController.text = this.originalRatings[choiceLabel];
       } else {
-        this
-            .unratedChoices
-            .putIfAbsent(choiceLabel, () => this.defaultRate.toString());
+        // "true" because user hasn't indicated that they've acknowledged the choice
+        this.unratedChoices.putIfAbsent(choiceLabel, () => true);
       }
 
       // TODO put map of choices that don't have rating in this constructor

--- a/front_end_pocket_poll/lib/groups_widgets/group_categories.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_categories.dart
@@ -53,7 +53,7 @@ class _GroupCategoriesState extends State<GroupCategories> {
           centerTitle: false,
           title: (widget.canEdit)
               ? Text(
-                  "Add Categories",
+                  "Select Categories",
                   style: TextStyle(
                       fontSize:
                           DefaultTextStyle.of(context).style.fontSize * 0.5),
@@ -245,7 +245,7 @@ class _GroupCategoriesState extends State<GroupCategories> {
         appBar: AppBar(
             centerTitle: false,
             title: (widget.canEdit)
-                ? Text("Add Categories",
+                ? Text("Select Categories",
                     style: TextStyle(
                         fontSize:
                             DefaultTextStyle.of(context).style.fontSize * 0.5))
@@ -262,7 +262,7 @@ class _GroupCategoriesState extends State<GroupCategories> {
         appBar: AppBar(
             centerTitle: false,
             title: (widget.canEdit)
-                ? Text("Add Categories",
+                ? Text("Select Categories",
                     style: TextStyle(
                         fontSize:
                             DefaultTextStyle.of(context).style.fontSize * 0.5))

--- a/front_end_pocket_poll/lib/groups_widgets/group_category_row.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_category_row.dart
@@ -35,16 +35,6 @@ class _GroupCategoryRowState extends State<GroupCategoryRow> {
     } else if (widget.categoryRatingTuple == null && widget.category != null) {
       this.activeUserOwnsCategory = true;
     }
-
-//    if (!this.activeUserOwnsCategory) {
-//      // find the num of other groups this category is in if its not active user's category
-//      for (String groupId in Globals.user.groups.keys) {
-//        if (widget.categoryRatingTuple.category.groups.containsKey(groupId) &&
-//            groupId != Globals.currentGroupResponse.group.groupId) {
-//          this.groupNum++;
-//        }
-//      }
-//    }
     super.initState();
   }
 

--- a/front_end_pocket_poll/lib/groups_widgets/group_category_row.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_category_row.dart
@@ -24,12 +24,10 @@ class GroupCategoryRow extends StatefulWidget {
 }
 
 class _GroupCategoryRowState extends State<GroupCategoryRow> {
-  int groupNum;
   bool activeUserOwnsCategory;
 
   @override
   void initState() {
-    this.groupNum = 0;
     this.activeUserOwnsCategory = false;
     if (widget.category == null && widget.categoryRatingTuple != null) {
       // means a tuple was passed in so the user doesn't own the category
@@ -38,15 +36,15 @@ class _GroupCategoryRowState extends State<GroupCategoryRow> {
       this.activeUserOwnsCategory = true;
     }
 
-    if (!this.activeUserOwnsCategory) {
-      // find the num of other groups this category is in if its not active user's category
-      for (String groupId in Globals.user.groups.keys) {
-        if (widget.categoryRatingTuple.category.groups.containsKey(groupId) &&
-            groupId != Globals.currentGroupResponse.group.groupId) {
-          this.groupNum++;
-        }
-      }
-    }
+//    if (!this.activeUserOwnsCategory) {
+//      // find the num of other groups this category is in if its not active user's category
+//      for (String groupId in Globals.user.groups.keys) {
+//        if (widget.categoryRatingTuple.category.groups.containsKey(groupId) &&
+//            groupId != Globals.currentGroupResponse.group.groupId) {
+//          this.groupNum++;
+//        }
+//      }
+//    }
     super.initState();
   }
 
@@ -83,8 +81,8 @@ class _GroupCategoryRowState extends State<GroupCategoryRow> {
                     }
                   },
                   child: AutoSizeText(
-                      (this.groupNum != 0)
-                          ? "${widget.category.categoryName}\n(Used in ${this.groupNum} of your other groups)"
+                      (!this.activeUserOwnsCategory)
+                          ? "${widget.category.categoryName}\n(@${widget.category.owner})"
                           : widget.category.categoryName,
                       maxLines: 2,
                       style: TextStyle(fontSize: 20),

--- a/front_end_pocket_poll/lib/groups_widgets/group_page.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_page.dart
@@ -283,7 +283,7 @@ class _GroupPageState extends State<GroupPage>
             Globals.currentGroupResponse.group.groupId,
             Globals.currentGroupResponse.group.events[eventId],
             eventId,
-            updatePage,
+            populateEventStages,
             refreshList);
         this.eventCards[considerTab].add(eventCard);
       } else if (eventMode == EventsManager.votingMode) {
@@ -291,7 +291,7 @@ class _GroupPageState extends State<GroupPage>
             Globals.currentGroupResponse.group.groupId,
             Globals.currentGroupResponse.group.events[eventId],
             eventId,
-            updatePage,
+            populateEventStages,
             refreshList);
         this.eventCards[votingTab].add(eventCard);
       } else if (eventMode == EventsManager.occurringMode) {
@@ -299,7 +299,7 @@ class _GroupPageState extends State<GroupPage>
             Globals.currentGroupResponse.group.groupId,
             Globals.currentGroupResponse.group.events[eventId],
             eventId,
-            updatePage,
+            populateEventStages,
             refreshList);
         this.eventCards[occurringTab].add(eventCard);
       } else if (eventMode == EventsManager.closedMode) {
@@ -307,7 +307,7 @@ class _GroupPageState extends State<GroupPage>
             Globals.currentGroupResponse.group.groupId,
             Globals.currentGroupResponse.group.events[eventId],
             eventId,
-            updatePage,
+            populateEventStages,
             refreshList);
         this.eventCards[closedTab].add(eventCard);
       }
@@ -410,7 +410,7 @@ class _GroupPageState extends State<GroupPage>
 
   /*
     Re-builds the page.
-    It's own method to allow the mark all seen button to disappear if marking the last event seen
+    It's own method to prevent exceptions if user clicks out of the page quickly
    */
   void updatePage() {
     if (!this.mounted) {

--- a/front_end_pocket_poll/lib/groups_widgets/groups_home.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/groups_home.dart
@@ -15,6 +15,7 @@ import 'package:front_end_pocket_poll/imports/globals.dart';
 import 'package:front_end_pocket_poll/imports/groups_manager.dart';
 import 'package:front_end_pocket_poll/imports/result_status.dart';
 import 'package:front_end_pocket_poll/imports/users_manager.dart';
+import 'package:front_end_pocket_poll/utilities/sorter.dart';
 import 'package:front_end_pocket_poll/widgets/login_page.dart';
 import 'package:front_end_pocket_poll/models/group_left.dart';
 import 'package:front_end_pocket_poll/models/message.dart';
@@ -93,7 +94,7 @@ class _GroupsHomeState extends State<GroupsHome>
               }
             }
             this.searchGroups = temp;
-            GroupsManager.sortByAlphaAscending(this.searchGroups);
+            Sorter.sortGroupRowsByAlphaAscending(this.searchGroups);
           });
         }
       } else {
@@ -118,7 +119,7 @@ class _GroupsHomeState extends State<GroupsHome>
               }
             }
             this.searchGroupsLeft = temp;
-            GroupsManager.sortByAlphaAscending(this.searchGroups);
+            Sorter.sortGroupRowsByAlphaAscending(this.searchGroups);
           });
         }
       }
@@ -595,13 +596,13 @@ class _GroupsHomeState extends State<GroupsHome>
 
   void setGroupsHomeSort(bool sendUpdate) {
     if (this.groupHomeSortVal == Globals.dateNewestSort) {
-      GroupsManager.sortByDateNewest(this.totalGroups);
+      Sorter.sortGroupRowsByDateNewest(this.totalGroups);
     } else if (this.groupHomeSortVal == Globals.dateOldestSort) {
-      GroupsManager.sortByDateOldest(totalGroups);
+      Sorter.sortGroupRowsByDateOldest(totalGroups);
     } else if (this.groupHomeSortVal == Globals.alphabeticalReverseSort) {
-      GroupsManager.sortByAlphaDescending(this.totalGroups);
+      Sorter.sortGroupRowsByAlphaDescending(this.totalGroups);
     } else if (this.groupHomeSortVal == Globals.alphabeticalSort) {
-      GroupsManager.sortByAlphaAscending(this.totalGroups);
+      Sorter.sortGroupRowsByAlphaAscending(this.totalGroups);
     }
     if (sendUpdate) {
       // blind send, don't care if it doesn't work since it's just a sort value
@@ -614,9 +615,9 @@ class _GroupsHomeState extends State<GroupsHome>
   void setGroupsLeftSort() {
     // don't need to update DB, separate method so there isn't a break in consistency
     if (this.groupsLeftSortVal == Globals.alphabeticalReverseSort) {
-      GroupsManager.sortByAlphaDescending(this.groupsLeft);
+      Sorter.sortGroupRowsByAlphaDescending(this.groupsLeft);
     } else if (this.groupsLeftSortVal == Globals.alphabeticalSort) {
-      GroupsManager.sortByAlphaAscending(this.groupsLeft);
+      Sorter.sortGroupRowsByAlphaAscending(this.groupsLeft);
     }
   }
 

--- a/front_end_pocket_poll/lib/imports/categories_manager.dart
+++ b/front_end_pocket_poll/lib/imports/categories_manager.dart
@@ -187,16 +187,4 @@ class CategoriesManager {
     }
     return retVal;
   }
-
-  // sorts a list of categories alphabetically (ascending)
-  static void sortByAlphaAscending(List<Category> categories) {
-    categories.sort((a, b) =>
-        a.categoryName.toUpperCase().compareTo(b.categoryName.toUpperCase()));
-  }
-
-  // sorts a list of categories alphabetically (descending)
-  static void sortByAlphaDescending(List<Category> categories) {
-    categories.sort((a, b) =>
-        b.categoryName.toUpperCase().compareTo(a.categoryName.toUpperCase()));
-  }
 }

--- a/front_end_pocket_poll/lib/imports/globals.dart
+++ b/front_end_pocket_poll/lib/imports/globals.dart
@@ -46,6 +46,7 @@ class Globals {
   static final DateFormat formatterWithTime =
       DateFormat.yMMMMd("en_US").add_jm();
   static final DateFormat dateFormatter = DateFormat.yMMMMd("en_US");
+  static final int defaultChoiceRating = 3;
 
   // sorting variables
   static final int dateNewestSort = 0;

--- a/front_end_pocket_poll/lib/imports/globals.dart
+++ b/front_end_pocket_poll/lib/imports/globals.dart
@@ -53,14 +53,12 @@ class Globals {
   static final int alphabeticalSort = 1;
   static final int alphabeticalReverseSort = 2;
   static final int dateOldestSort = 3;
-  static final int defaultChoiceSort = 4;
-  static final int choiceRatingAscending = 5;
-  static final int choiceRatingDescending = 6;
+  static final int choiceRatingAscending = 4;
+  static final int choiceRatingDescending = 5;
   static final String alphabeticalSortString = "Alphabetical (A-Z)";
   static final String alphabeticalReverseSortString = "Alphabetical (Z-A)";
   static final String dateNewestSortString = "Date Modified (Newest)";
   static final String dateOldestSortString = "Date Modified (Oldest)";
-  static final String defaultChoiceSortString = "Original Insert Order";
   static final String choiceRatingAscendingSortString = "Ratings (Ascending)";
   static final String choiceRatingDescendingSortString = "Ratings (Descending)";
 

--- a/front_end_pocket_poll/lib/imports/globals.dart
+++ b/front_end_pocket_poll/lib/imports/globals.dart
@@ -6,16 +6,13 @@ import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class Globals {
-  static Color pocketPollDarkGreen = Color(0xff106126);
-  static Color pocketPollGreen = Color(0xff5ce080);
-  static Color pocketPollGrey = Color(0xff303030);
   static String username;
   static User user;
-  static DateFormat formatterWithTime = DateFormat.yMMMMd("en_US").add_jm();
-  static DateFormat dateFormatter = DateFormat.yMMMMd("en_US");
   static GetGroupResponse currentGroupResponse = new GetGroupResponse();
   static List<CategoryRatingTuple> cachedCategories =
       new List<CategoryRatingTuple>();
+  static bool fireBaseConfigured = false;
+  static Function refreshGroupPage;
   static SharedPreferences sharedPrefs;
 
   static Future<SharedPreferences> getSharedPrefs() async {
@@ -25,9 +22,11 @@ class Globals {
     return sharedPrefs;
   }
 
-  static bool fireBaseConfigured = false;
-  static Function refreshGroupPage;
-  static ThemeData darkTheme = ThemeData(
+  // *************** CONSTANTS ***************
+  static final Color pocketPollDarkGreen = Color(0xff106126);
+  static final Color pocketPollGreen = Color(0xff5ce080);
+  static final Color pocketPollGrey = Color(0xff303030);
+  static final ThemeData darkTheme = ThemeData(
       brightness: Brightness.dark,
       primarySwatch: Colors.green,
       primaryColor: pocketPollGreen,
@@ -36,7 +35,7 @@ class Globals {
       buttonTheme: ButtonThemeData(buttonColor: Color(0xff106126)),
       primaryTextTheme: TextTheme(title: TextStyle(color: Colors.black)),
       textTheme: TextTheme(body1: TextStyle(color: Colors.white)));
-  static ThemeData lightTheme = ThemeData(
+  static final ThemeData lightTheme = ThemeData(
       brightness: Brightness.light,
       primarySwatch: Colors.green,
       primaryColor: pocketPollGreen,
@@ -44,8 +43,11 @@ class Globals {
       primaryColorDark: Colors.black,
       primaryTextTheme: TextTheme(title: TextStyle(color: Colors.black)),
       textTheme: TextTheme(body1: TextStyle(color: Colors.black)));
+  static final DateFormat formatterWithTime =
+      DateFormat.yMMMMd("en_US").add_jm();
+  static final DateFormat dateFormatter = DateFormat.yMMMMd("en_US");
 
-  // *************** CONSTANTS ***************
+  // sorting variables
   static final int dateNewestSort = 0;
   static final int alphabeticalSort = 1;
   static final int alphabeticalReverseSort = 2;
@@ -60,6 +62,8 @@ class Globals {
   static final String defaultChoiceSortString = "Original Insert Order";
   static final String choiceRatingAscendingSortString = "Ratings (Ascending)";
   static final String choiceRatingDescendingSortString = "Ratings (Descending)";
+
+  // notification actions
   static final String removedFromGroupAction = "removedFromGroup";
   static final String addedToGroupAction = "addedToGroup";
   static final String eventCreatedAction = "eventCreated";
@@ -97,6 +101,7 @@ class Globals {
   static final int minChoiceRating = 0;
   static final int maxChoiceRatingDigits = maxChoiceRating.toString().length;
 
+  // URLS
   static final String resetPasswordUrl =
       "https://pocket-poll.auth.us-east-2.amazoncognito.com/forgotPassword?client_id=7eh4otm1r5p351d1u9j3h3rf1o&response_type=code&redirect_uri=https://pocket-poll-documents.s3.us-east-2.amazonaws.com/login_redirect.html";
   static final String imageUrl =

--- a/front_end_pocket_poll/lib/imports/globals.dart
+++ b/front_end_pocket_poll/lib/imports/globals.dart
@@ -17,16 +17,49 @@ class Globals {
   static List<CategoryRatingTuple> cachedCategories =
       new List<CategoryRatingTuple>();
   static SharedPreferences sharedPrefs;
-  static int dateNewestSort = 0;
-  static int alphabeticalSort = 1;
-  static int alphabeticalReverseSort = 2;
-  static int dateOldestSort = 3;
-  static String alphabeticalSortString = "Alphabetical (A-Z)";
-  static String alphabeticalReverseSortString = "Alphabetical (Z-A)";
-  static String dateNewestSortString = "Date Modified (Newest)";
-  static String dateOldestSortString = "Date Modified (Oldest)";
+
+  static Future<SharedPreferences> getSharedPrefs() async {
+    if (sharedPrefs == null) {
+      sharedPrefs = await SharedPreferences.getInstance();
+    }
+    return sharedPrefs;
+  }
+
   static bool fireBaseConfigured = false;
   static Function refreshGroupPage;
+  static ThemeData darkTheme = ThemeData(
+      brightness: Brightness.dark,
+      primarySwatch: Colors.green,
+      primaryColor: pocketPollGreen,
+      accentColor: pocketPollGreen,
+      primaryColorDark: Colors.black,
+      buttonTheme: ButtonThemeData(buttonColor: Color(0xff106126)),
+      primaryTextTheme: TextTheme(title: TextStyle(color: Colors.black)),
+      textTheme: TextTheme(body1: TextStyle(color: Colors.white)));
+  static ThemeData lightTheme = ThemeData(
+      brightness: Brightness.light,
+      primarySwatch: Colors.green,
+      primaryColor: pocketPollGreen,
+      accentColor: pocketPollGreen,
+      primaryColorDark: Colors.black,
+      primaryTextTheme: TextTheme(title: TextStyle(color: Colors.black)),
+      textTheme: TextTheme(body1: TextStyle(color: Colors.black)));
+
+  // *************** CONSTANTS ***************
+  static final int dateNewestSort = 0;
+  static final int alphabeticalSort = 1;
+  static final int alphabeticalReverseSort = 2;
+  static final int dateOldestSort = 3;
+  static final int defaultChoiceSort = 4;
+  static final int choiceRatingAscending = 5;
+  static final int choiceRatingDescending = 6;
+  static final String alphabeticalSortString = "Alphabetical (A-Z)";
+  static final String alphabeticalReverseSortString = "Alphabetical (Z-A)";
+  static final String dateNewestSortString = "Date Modified (Newest)";
+  static final String dateOldestSortString = "Date Modified (Oldest)";
+  static final String defaultChoiceSortString = "Original Insert Order";
+  static final String choiceRatingAscendingSortString = "Ratings (Ascending)";
+  static final String choiceRatingDescendingSortString = "Ratings (Descending)";
   static final String removedFromGroupAction = "removedFromGroup";
   static final String addedToGroupAction = "addedToGroup";
   static final String eventCreatedAction = "eventCreated";
@@ -64,9 +97,9 @@ class Globals {
   static final int minChoiceRating = 0;
   static final int maxChoiceRatingDigits = maxChoiceRating.toString().length;
 
-  static String resetPasswordUrl =
+  static final String resetPasswordUrl =
       "https://pocket-poll.auth.us-east-2.amazoncognito.com/forgotPassword?client_id=7eh4otm1r5p351d1u9j3h3rf1o&response_type=code&redirect_uri=https://pocket-poll-documents.s3.us-east-2.amazonaws.com/login_redirect.html";
-  static String imageUrl =
+  static final String imageUrl =
       "https://pocketpoll-images.s3.us-east-2.amazonaws.com/";
   static final String termsUrl =
       "https://pocket-poll-documents.s3.us-east-2.amazonaws.com/terms_conditions.html";
@@ -74,29 +107,4 @@ class Globals {
       "https://pocket-poll-documents.s3.us-east-2.amazonaws.com/privacy_policy.html";
   static final String flutterUrl = "https://flutter.dev/";
   static final String awsUrl = "https://aws.amazon.com/";
-
-  static ThemeData darkTheme = ThemeData(
-      brightness: Brightness.dark,
-      primarySwatch: Colors.green,
-      primaryColor: pocketPollGreen,
-      accentColor: pocketPollGreen,
-      primaryColorDark: Colors.black,
-      buttonTheme: ButtonThemeData(buttonColor: Color(0xff106126)),
-      primaryTextTheme: TextTheme(title: TextStyle(color: Colors.black)),
-      textTheme: TextTheme(body1: TextStyle(color: Colors.white)));
-  static ThemeData lightTheme = ThemeData(
-      brightness: Brightness.light,
-      primarySwatch: Colors.green,
-      primaryColor: pocketPollGreen,
-      accentColor: pocketPollGreen,
-      primaryColorDark: Colors.black,
-      primaryTextTheme: TextTheme(title: TextStyle(color: Colors.black)),
-      textTheme: TextTheme(body1: TextStyle(color: Colors.black)));
-
-  static Future<SharedPreferences> getSharedPrefs() async {
-    if (sharedPrefs == null) {
-      sharedPrefs = await SharedPreferences.getInstance();
-    }
-    return sharedPrefs;
-  }
 }

--- a/front_end_pocket_poll/lib/imports/groups_manager.dart
+++ b/front_end_pocket_poll/lib/imports/groups_manager.dart
@@ -406,34 +406,6 @@ class GroupsManager {
     return retVal;
   }
 
-  // sorts a list of groups by date modified (ascending)
-  static void sortByDateNewest(List<UserGroup> groups) {
-    groups.sort((a, b) => DateTime.parse(b.lastActivity)
-        .compareTo(DateTime.parse(a.lastActivity)));
-  }
-
-  // sorts a list of groups by date modified (descending)
-  static void sortByDateOldest(List<UserGroup> groups) {
-    groups.sort((a, b) => DateTime.parse(a.lastActivity)
-        .compareTo(DateTime.parse(b.lastActivity)));
-  }
-
-  // sorts a list of groups alphabetically (ascending)
-  static void sortByAlphaAscending(List<GroupInterface> groups) {
-    groups.sort((a, b) => a
-        .getGroupName()
-        .toUpperCase()
-        .compareTo(b.getGroupName().toUpperCase()));
-  }
-
-  // sorts a list of groups alphabetically (descending)
-  static void sortByAlphaDescending(List<GroupInterface> groups) {
-    groups.sort((a, b) => b
-        .getGroupName()
-        .toUpperCase()
-        .compareTo(a.getGroupName().toUpperCase()));
-  }
-
   static Future<ResultStatus<List<CategoryRatingTuple>>> getAllCategoriesList(
       final String groupId) async {
     ResultStatus<List<CategoryRatingTuple>> retVal =

--- a/front_end_pocket_poll/lib/utilities/sorter.dart
+++ b/front_end_pocket_poll/lib/utilities/sorter.dart
@@ -1,13 +1,13 @@
 import 'package:front_end_pocket_poll/categories_widgets/choice_row.dart';
 import 'package:front_end_pocket_poll/imports/globals.dart';
+import 'package:front_end_pocket_poll/models/category.dart';
+import 'package:front_end_pocket_poll/models/group_interface.dart';
+import 'package:front_end_pocket_poll/models/user_group.dart';
 
 class Sorter {
   // sorts choice rows based on a given sort value. Empty choices always put on top
   static void sortChoiceRows(List<ChoiceRow> choiceRows, int sortVal) {
-    if (sortVal == Globals.defaultChoiceSort) {
-      // sort by choice id. we want the highest choice id on the top
-      choiceRows.sort((a, b) => b.choiceNumber.compareTo(a.choiceNumber));
-    } else if (sortVal == Globals.alphabeticalSort) {
+    if (sortVal == Globals.alphabeticalSort) {
       choiceRows.sort((a, b) => a.labelController.text
           .toString()
           .toLowerCase()
@@ -35,5 +35,45 @@ class Sorter {
         choiceRows.insert(0, choiceRow);
       }
     }
+  }
+
+  // sorts a list of groups by date modified (ascending)
+  static void sortGroupRowsByDateNewest(List<UserGroup> groups) {
+    groups.sort((a, b) => DateTime.parse(b.lastActivity)
+        .compareTo(DateTime.parse(a.lastActivity)));
+  }
+
+  // sorts a list of groups by date modified (descending)
+  static void sortGroupRowsByDateOldest(List<UserGroup> groups) {
+    groups.sort((a, b) => DateTime.parse(a.lastActivity)
+        .compareTo(DateTime.parse(b.lastActivity)));
+  }
+
+  // sorts a list of groups alphabetically (ascending)
+  static void sortGroupRowsByAlphaAscending(List<GroupInterface> groups) {
+    groups.sort((a, b) => a
+        .getGroupName()
+        .toUpperCase()
+        .compareTo(b.getGroupName().toUpperCase()));
+  }
+
+  // sorts a list of groups alphabetically (descending)
+  static void sortGroupRowsByAlphaDescending(List<GroupInterface> groups) {
+    groups.sort((a, b) => b
+        .getGroupName()
+        .toUpperCase()
+        .compareTo(a.getGroupName().toUpperCase()));
+  }
+
+  // sorts a list of categories alphabetically (ascending)
+  static void sortCategoriesByAlphaAscending(List<Category> categories) {
+    categories.sort((a, b) =>
+        a.categoryName.toLowerCase().compareTo(b.categoryName.toLowerCase()));
+  }
+
+  // sorts a list of categories alphabetically (descending)
+  static void sortCategoriesByAlphaDescending(List<Category> categories) {
+    categories.sort((a, b) =>
+        b.categoryName.toLowerCase().compareTo(a.categoryName.toLowerCase()));
   }
 }

--- a/front_end_pocket_poll/lib/utilities/sorter.dart
+++ b/front_end_pocket_poll/lib/utilities/sorter.dart
@@ -1,0 +1,39 @@
+import 'package:front_end_pocket_poll/categories_widgets/choice_row.dart';
+import 'package:front_end_pocket_poll/imports/globals.dart';
+
+class Sorter {
+  // sorts choice rows based on a given sort value. Empty choices always put on top
+  static void sortChoiceRows(List<ChoiceRow> choiceRows, int sortVal) {
+    if (sortVal == Globals.defaultChoiceSort) {
+      // sort by choice id. we want the highest choice id on the top
+      choiceRows.sort((a, b) => b.choiceNumber.compareTo(a.choiceNumber));
+    } else if (sortVal == Globals.alphabeticalSort) {
+      choiceRows.sort((a, b) => a.labelController.text
+          .toString()
+          .toLowerCase()
+          .compareTo(b.labelController.text.toString().toLowerCase()));
+    } else if (sortVal == Globals.alphabeticalReverseSort) {
+      choiceRows.sort((a, b) => b.labelController.text
+          .toString()
+          .toLowerCase()
+          .compareTo(a.labelController.text.toString().toLowerCase()));
+    } else if (sortVal == Globals.choiceRatingAscending) {
+      // smallest rating at top of the list
+      choiceRows.sort((a, b) => a.rateController.text
+          .toString()
+          .compareTo(b.rateController.text.toString()));
+    } else if (sortVal == Globals.choiceRatingDescending) {
+      // smallest rating at top of the list
+      choiceRows.sort((a, b) => b.rateController.text
+          .toString()
+          .compareTo(a.rateController.text.toString()));
+    }
+    for (ChoiceRow choiceRow in choiceRows) {
+      if (choiceRow.labelController.text.isEmpty) {
+        // we want all empty labeled choice rows to always be at the top
+        choiceRows.remove(choiceRow);
+        choiceRows.insert(0, choiceRow);
+      }
+    }
+  }
+}

--- a/front_end_pocket_poll/lib/utilities/utilities.dart
+++ b/front_end_pocket_poll/lib/utilities/utilities.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:front_end_pocket_poll/categories_widgets/choice_row.dart';
 import 'package:front_end_pocket_poll/imports/globals.dart';
 import 'package:front_end_pocket_poll/imports/user_tokens_manager.dart';
 import 'package:front_end_pocket_poll/imports/users_manager.dart';
@@ -288,38 +287,4 @@ void changeTheme(BuildContext context) {
 // used for returning a UTC timestamp to the DB for new events
 int getUtcSecondsSinceEpoch(final DateTime dateTime) {
   return (dateTime.millisecondsSinceEpoch / 1000).ceil();
-}
-
-void sortChoiceRows(List<ChoiceRow> choiceRows, int sortVal) {
-  if (sortVal == Globals.defaultChoiceSort) {
-    // sort by choice id. we want the highest choice id on the top
-    choiceRows.sort((a, b) => b.choiceNumber.compareTo(a.choiceNumber));
-  } else if (sortVal == Globals.alphabeticalSort) {
-    choiceRows.sort((a, b) => a.labelController.text
-        .toString()
-        .toLowerCase()
-        .compareTo(b.labelController.text.toString().toLowerCase()));
-  } else if (sortVal == Globals.alphabeticalReverseSort) {
-    choiceRows.sort((a, b) => b.labelController.text
-        .toString()
-        .toLowerCase()
-        .compareTo(a.labelController.text.toString().toLowerCase()));
-  } else if (sortVal == Globals.choiceRatingAscending) {
-    // smallest rating at top of the list
-    choiceRows.sort((a, b) => a.rateController.text
-        .toString()
-        .compareTo(b.rateController.text.toString()));
-  } else if (sortVal == Globals.choiceRatingDescending) {
-    // smallest rating at top of the list
-    choiceRows.sort((a, b) => b.rateController.text
-        .toString()
-        .compareTo(a.rateController.text.toString()));
-  }
-  for (ChoiceRow choiceRow in choiceRows) {
-    if (choiceRow.labelController.text.isEmpty) {
-      // we want all empty labeled choice rows to always be at the top
-      choiceRows.remove(choiceRow);
-      choiceRows.insert(0, choiceRow);
-    }
-  }
 }

--- a/front_end_pocket_poll/lib/utilities/utilities.dart
+++ b/front_end_pocket_poll/lib/utilities/utilities.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:front_end_pocket_poll/categories_widgets/choice_row.dart';
 import 'package:front_end_pocket_poll/imports/globals.dart';
-import 'package:front_end_pocket_poll/imports/result_status.dart';
 import 'package:front_end_pocket_poll/imports/user_tokens_manager.dart';
 import 'package:front_end_pocket_poll/imports/users_manager.dart';
 import 'package:front_end_pocket_poll/models/favorite.dart';
@@ -288,4 +288,38 @@ void changeTheme(BuildContext context) {
 // used for returning a UTC timestamp to the DB for new events
 int getUtcSecondsSinceEpoch(final DateTime dateTime) {
   return (dateTime.millisecondsSinceEpoch / 1000).ceil();
+}
+
+void sortChoiceRows(List<ChoiceRow> choiceRows, int sortVal) {
+  if (sortVal == Globals.defaultChoiceSort) {
+    // sort by choice id. we want the highest choice id on the top
+    choiceRows.sort((a, b) => b.choiceNumber.compareTo(a.choiceNumber));
+  } else if (sortVal == Globals.alphabeticalSort) {
+    choiceRows.sort((a, b) => a.labelController.text
+        .toString()
+        .toLowerCase()
+        .compareTo(b.labelController.text.toString().toLowerCase()));
+  } else if (sortVal == Globals.alphabeticalReverseSort) {
+    choiceRows.sort((a, b) => b.labelController.text
+        .toString()
+        .toLowerCase()
+        .compareTo(a.labelController.text.toString().toLowerCase()));
+  } else if (sortVal == Globals.choiceRatingAscending) {
+    // smallest rating at top of the list
+    choiceRows.sort((a, b) => a.rateController.text
+        .toString()
+        .compareTo(b.rateController.text.toString()));
+  } else if (sortVal == Globals.choiceRatingDescending) {
+    // smallest rating at top of the list
+    choiceRows.sort((a, b) => b.rateController.text
+        .toString()
+        .compareTo(a.rateController.text.toString()));
+  }
+  for (ChoiceRow choiceRow in choiceRows) {
+    if (choiceRow.labelController.text.isEmpty) {
+      // we want all empty labeled choice rows to always be at the top
+      choiceRows.remove(choiceRow);
+      choiceRows.insert(0, choiceRow);
+    }
+  }
 }

--- a/front_end_pocket_poll/test_driver/app_test.dart
+++ b/front_end_pocket_poll/test_driver/app_test.dart
@@ -89,7 +89,7 @@ void main() {
       await driver.enterText(getRandomCategoryName());
 
       // enter a choice
-      var choiceNameField = find.byValueKey("choice_row:choice_name_input:1");
+      var choiceNameField = find.byValueKey("choice_row:choice_name_input:0");
       await driver.tap(choiceNameField);
       await driver.enterText(getRandomChoiceName());
 
@@ -113,7 +113,7 @@ void main() {
       await driver.enterText(getRandomCategoryName());
 
       // edit a choice
-      var choiceNameField = find.byValueKey("choice_row:choice_name_input:1");
+      var choiceNameField = find.byValueKey("choice_row:choice_name_input:0");
       await driver.tap(choiceNameField);
       await driver.enterText(getRandomChoiceName());
 
@@ -507,7 +507,7 @@ void main() {
       await driver.waitFor(find.byValueKey("event_update_ratings:scaffold"));
 
       // update the first rating
-      var ratingInput = find.byValueKey("choice_row:rating_input:1");
+      var ratingInput = find.byValueKey("choice_row:rating_input:0");
       await driver.tap(ratingInput);
       await driver.enterText("5");
 


### PR DESCRIPTION
# Overview
Editing a category/updating ratings just got a whole lot better. You can now sort choices (empty ones are just always kept on the top), and choices that are modified are shown as such just as new ones are. Choices that you do not have ratings for will be highlighted and if you don't update the rating for the choice we just assume that the default is fine and send a blind send to the backend.

Did a lot of other small changes to the category pages as well as fixed some bugs I spotted elsewhere in the app (such as considering not working locally).

# Testing
Ran behavioral tests and tried to test every flow in the categories pages.