### PR TITLE
Lots of small touch ups and fixes.

### DIFF
--- a/backEnd/src/main/java/handlers/DeleteGroupHandler.java
+++ b/backEnd/src/main/java/handlers/DeleteGroupHandler.java
@@ -95,7 +95,7 @@ public class DeleteGroupHandler implements ApiRequestHandler {
    */
   private ResultStatus deleteAllPendingGroupEvents(final Group deletedGroup) {
     final Set<String> pendingEventIds = deletedGroup.getEvents().entrySet().stream()
-        .filter((e) -> (new EventForSorting(e.getValue()).isPending()))
+        .filter((e) -> (new EventForSorting(e.getKey(), e.getValue()).isPending()))
         .map(Entry::getKey).collect(Collectors.toSet());
 
     if (pendingEventIds.isEmpty()) {

--- a/backEnd/src/main/java/handlers/GetAllBatchesOfEventsHandler.java
+++ b/backEnd/src/main/java/handlers/GetAllBatchesOfEventsHandler.java
@@ -95,8 +95,9 @@ public class GetAllBatchesOfEventsHandler implements ApiRequestHandler {
     final Map<String, EventForSorting> searchingEventsBatch = group.getEvents()
         .entrySet()
         .stream()
-        .collect(toMap(Entry::getKey, (Map.Entry e) -> new EventForSorting((Event) e.getValue(),
-            this.dbAccessManager.nowObj())));
+        .collect(toMap(Entry::getKey,
+            (Map.Entry<String, Event> e) -> new EventForSorting(e.getKey(), e.getValue(),
+                this.dbAccessManager.nowObj())));
 
     //separate the events into their appropriate buckets
     String priorityLabel;

--- a/backEnd/src/main/java/handlers/GetAllBatchesOfEventsHandler.java
+++ b/backEnd/src/main/java/handlers/GetAllBatchesOfEventsHandler.java
@@ -34,6 +34,16 @@ public class GetAllBatchesOfEventsHandler implements ApiRequestHandler {
     this.metrics = metrics;
   }
 
+  /**
+   * This function handles getting all of the batches present in all of the events lists possible.
+   *
+   * @param activeUser   The active user making the request.
+   * @param groupId      The id of the group that all of the events should be retrieved from.
+   * @param batchIndexes The max batch ids loaded in all of the events lists.
+   * @param maxBatches   The max batches allowed to be loaded. This with the batchIndexes gives
+   *                     information to know all of tha batches that need information retrieved.
+   * @return Standard result status object giving insight on whether the request was successful.
+   */
   public ResultStatus handle(final String activeUser, final String groupId,
       final Map<String, Integer> batchIndexes, final Integer maxBatches) {
     final String classMethod = "GetAllBatchesOfEventsHandler.handle";

--- a/backEnd/src/main/java/handlers/GetBatchOfEventsHandler.java
+++ b/backEnd/src/main/java/handlers/GetBatchOfEventsHandler.java
@@ -130,7 +130,8 @@ public class GetBatchOfEventsHandler implements ApiRequestHandler {
         .entrySet()
         .stream()
         .collect(collectingAndThen(
-            toMap(Entry::getKey, (Map.Entry e) -> new EventForSorting((Event) e.getValue(), now)),
+            toMap(Entry::getKey,
+                (Map.Entry<String, Event> e) -> new EventForSorting(e.getKey(), e.getValue(), now)),
             LinkedHashMap::new));
 
     if (batchType.equals(EVENTS_TYPE_NEW)) {
@@ -204,7 +205,9 @@ public class GetBatchOfEventsHandler implements ApiRequestHandler {
           .entrySet()
           .stream()
           .collect(collectingAndThen(
-              toMap(Entry::getKey, (Map.Entry e) -> new EventForSorting((Event) e.getValue(), now)),
+              toMap(Entry::getKey,
+                  (Map.Entry<String, Event> e) -> new EventForSorting(e.getKey(), e.getValue(),
+                      now)),
               LinkedHashMap::new));
     } // else there are no events in this range and we return the empty map
 

--- a/backEnd/src/main/java/managers/DbAccessManager.java
+++ b/backEnd/src/main/java/managers/DbAccessManager.java
@@ -57,6 +57,9 @@ public class DbAccessManager {
 
   private final HashMap<String, Item> cache;
 
+  //lambdas occur 'instantaneously' so save the now at initialization and use throughout
+  private final LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+
   public DbAccessManager() {
     final Regions region = Regions.US_EAST_2;
     this.client = (AmazonDynamoDBClient) AmazonDynamoDBClient.builder()
@@ -76,11 +79,11 @@ public class DbAccessManager {
   }
 
   public String now() {
-    return LocalDateTime.now(ZoneId.of("UTC")).format(this.dateTimeFormatter);
+    return this.now.format(this.dateTimeFormatter);
   }
 
   public LocalDateTime nowObj() {
-    return LocalDateTime.now(ZoneId.of("UTC"));
+    return this.now;
   }
 
   public DateTimeFormatter getDateTimeFormatter() {

--- a/front_end_pocket_poll/lib/about_widgets/about_descriptions.dart
+++ b/front_end_pocket_poll/lib/about_widgets/about_descriptions.dart
@@ -55,7 +55,7 @@ class AboutDescriptions {
       </ol>
       <p>If you have notifications enabled, you will receive a notification whenever an event goes to a different stage.</p>
       <p>When creating an event, the consider and voting stages can be skipped by either hitting the skip buttons next to the input fields or by putting the number 0 in for the time.</p>
-      <p>The default consider and voting durations are set in the group settings page.</p>
+      <p>The default consider and voting durations can be updated on one's account settings page.</p>
       <P>When clicking on the details of an event, you can add that event to your calendar app by clicking the calendar icon button in the top right corner of the page.</P>
     """);
 }

--- a/front_end_pocket_poll/lib/categories_widgets/category_create.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_create.dart
@@ -271,7 +271,8 @@ class _CategoryCreateState extends State<CategoryCreate> {
         )
         .then((_) {
       // at the bottom of the list now, so request the focus of the choice row
-      choiceRow.requestFocus(context);
+      SchedulerBinding.instance
+          .addPostFrameCallback((_) => choiceRow.requestFocus(context));
     });
   }
 

--- a/front_end_pocket_poll/lib/categories_widgets/category_edit.dart
+++ b/front_end_pocket_poll/lib/categories_widgets/category_edit.dart
@@ -374,7 +374,8 @@ class _CategoryEditState extends State<CategoryEdit> {
         )
         .then((_) {
       // at the bottom of the list now, so request the focus of the choice row
-      choiceRow.requestFocus(context);
+      SchedulerBinding.instance
+          .addPostFrameCallback((_) => choiceRow.requestFocus(context));
     });
   }
 

--- a/front_end_pocket_poll/lib/events_widgets/event_card_closed.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_card_closed.dart
@@ -30,6 +30,11 @@ class EventCardClosed extends StatefulWidget implements EventCardInterface {
   Event getEvent() {
     return this.event;
   }
+
+  @override
+  String getEventId() {
+    return this.eventId;
+  }
 }
 
 class _EventCardClosedState extends State<EventCardClosed> {

--- a/front_end_pocket_poll/lib/events_widgets/event_card_consider.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_card_consider.dart
@@ -30,6 +30,11 @@ class EventCardConsider extends StatefulWidget implements EventCardInterface {
   Event getEvent() {
     return this.event;
   }
+
+  @override
+  String getEventId() {
+    return this.eventId;
+  }
 }
 
 class _EventCardConsiderState extends State<EventCardConsider> {

--- a/front_end_pocket_poll/lib/events_widgets/event_card_occurring.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_card_occurring.dart
@@ -30,6 +30,11 @@ class EventCardOccurring extends StatefulWidget implements EventCardInterface {
   Event getEvent() {
     return this.event;
   }
+
+  @override
+  String getEventId() {
+    return this.eventId;
+  }
 }
 
 class _EventCardOccurringState extends State<EventCardOccurring> {

--- a/front_end_pocket_poll/lib/events_widgets/event_card_voting.dart
+++ b/front_end_pocket_poll/lib/events_widgets/event_card_voting.dart
@@ -30,6 +30,11 @@ class EventCardVoting extends StatefulWidget implements EventCardInterface {
   Event getEvent() {
     return this.event;
   }
+
+  @override
+  String getEventId() {
+    return this.eventId;
+  }
 }
 
 class _EventCardVotingState extends State<EventCardVoting> {

--- a/front_end_pocket_poll/lib/events_widgets/events_list.dart
+++ b/front_end_pocket_poll/lib/events_widgets/events_list.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:front_end_pocket_poll/imports/events_manager.dart';
 import 'package:front_end_pocket_poll/imports/globals.dart';
 import 'package:front_end_pocket_poll/models/event_card_interface.dart';
+import 'package:front_end_pocket_poll/utilities/sorter.dart';
 
 class EventsList extends StatefulWidget {
   static final int eventsTypeNew = 0;
@@ -132,69 +132,7 @@ class _EventsListState extends State<EventsList> {
       );
     } else {
       //sort the events
-      widget.events.sort((a, b) {
-        if (a.getEventMode() > b.getEventMode()) {
-          return -1;
-        } else if (b.getEventMode() > a.getEventMode()) {
-          return 1;
-        } else {
-          //cards are same priority
-          if (a.getEventMode() == EventsManager.considerMode) {
-            if (a.getEvent().pollBegin.isBefore(b.getEvent().pollBegin)) {
-              return -1;
-            } else if (b
-                .getEvent()
-                .pollBegin
-                .isBefore(a.getEvent().pollBegin)) {
-              return 1;
-            } else {
-              //same time, give definitive sort based on ids
-              return a.getEventId().compareTo(b.getEventId());
-            }
-          } else if (a.getEventMode() == EventsManager.votingMode) {
-            if (a.getEvent().pollEnd.isBefore(b.getEvent().pollEnd)) {
-              return -1;
-            } else if (b.getEvent().pollEnd.isBefore(a.getEvent().pollEnd)) {
-              return 1;
-            } else {
-              //same time, give definitive sort based on ids
-              return a.getEventId().compareTo(b.getEventId());
-            }
-          } else if (a.getEventMode() == EventsManager.occurringMode) {
-            if (a
-                .getEvent()
-                .eventStartDateTime
-                .isBefore(b.getEvent().eventStartDateTime)) {
-              return -1;
-            } else if (b
-                .getEvent()
-                .eventStartDateTime
-                .isBefore(a.getEvent().eventStartDateTime)) {
-              return 1;
-            } else {
-              //same time, give definitive sort based on ids
-              return a.getEventId().compareTo(b.getEventId());
-            }
-          } else {
-            //event is in closed mode. we want the most recent times here
-            // otherwise the first event would always be at the top
-            if (a
-                .getEvent()
-                .eventStartDateTime
-                .isBefore(b.getEvent().eventStartDateTime)) {
-              return 1;
-            } else if (b
-                .getEvent()
-                .eventStartDateTime
-                .isBefore(a.getEvent().eventStartDateTime)) {
-              return -1;
-            } else {
-              //same time, give definitive sort based on ids
-              return a.getEventId().compareTo(b.getEventId());
-            }
-          }
-        }
-      });
+      Sorter.sortEventCardInterfaces(widget.events);
 
       List<Widget> widgetList = new List<Widget>.from(widget.events);
 

--- a/front_end_pocket_poll/lib/events_widgets/events_list.dart
+++ b/front_end_pocket_poll/lib/events_widgets/events_list.dart
@@ -69,6 +69,7 @@ class _EventsListState extends State<EventsList> {
         !loadingBatch) {
       //show a loading indicator
       Scaffold.of(this.context).showSnackBar(SnackBar(
+          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
           content: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [CircularProgressIndicator()])));

--- a/front_end_pocket_poll/lib/events_widgets/events_list.dart
+++ b/front_end_pocket_poll/lib/events_widgets/events_list.dart
@@ -195,6 +195,7 @@ class _EventsListState extends State<EventsList> {
       return Scrollbar(
           key: UniqueKey(),
           child: ListView.builder(
+              physics: AlwaysScrollableScrollPhysics(),
               controller: this.scrollController,
               shrinkWrap: true,
               itemCount: widgetList.length,

--- a/front_end_pocket_poll/lib/events_widgets/events_list.dart
+++ b/front_end_pocket_poll/lib/events_widgets/events_list.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:front_end_pocket_poll/imports/events_manager.dart';
 import 'package:front_end_pocket_poll/imports/globals.dart';
@@ -66,6 +67,12 @@ class _EventsListState extends State<EventsList> {
             this.scrollController.position.maxScrollExtent &&
         !this.scrollController.position.outOfRange &&
         !loadingBatch) {
+      //show a loading indicator
+      Scaffold.of(this.context).showSnackBar(SnackBar(
+          content: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [CircularProgressIndicator()])));
+
       this.loadingBatch = true;
 
       widget
@@ -74,6 +81,9 @@ class _EventsListState extends State<EventsList> {
           .then((_) {
         // if the batch didn't get anything, there will be no page refresh
         this.loadingBatch = false;
+
+        //remove the loading indicator
+        Scaffold.of(this.context).removeCurrentSnackBar();
       });
     }
 

--- a/front_end_pocket_poll/lib/events_widgets/events_list.dart
+++ b/front_end_pocket_poll/lib/events_widgets/events_list.dart
@@ -102,9 +102,6 @@ class _EventsListState extends State<EventsList> {
         this.loadingBatch = false;
       });
     }
-
-    //TODO fix the last batch jump (maybe put empty cards at the bottom of the
-    // list if the batch isn't of size BATCH_SIZE
   }
 
   @override
@@ -134,36 +131,67 @@ class _EventsListState extends State<EventsList> {
         ],
       );
     } else {
-      // sort the events
+      //sort the events
       widget.events.sort((a, b) {
-        // this if statement is only needed in the new tab since all of the event types can be in it
         if (a.getEventMode() > b.getEventMode()) {
           return -1;
         } else if (b.getEventMode() > a.getEventMode()) {
           return 1;
         } else {
-          // cards are same priority
+          //cards are same priority
           if (a.getEventMode() == EventsManager.considerMode) {
-            return b.getEvent().pollBegin.isBefore(a.getEvent().pollBegin)
-                ? 1
-                : -1;
+            if (a.getEvent().pollBegin.isBefore(b.getEvent().pollBegin)) {
+              return -1;
+            } else if (b
+                .getEvent()
+                .pollBegin
+                .isBefore(a.getEvent().pollBegin)) {
+              return 1;
+            } else {
+              //same time, give definitive sort based on ids
+              return a.getEventId().compareTo(b.getEventId());
+            }
           } else if (a.getEventMode() == EventsManager.votingMode) {
-            return b.getEvent().pollEnd.isBefore(a.getEvent().pollEnd) ? 1 : -1;
+            if (a.getEvent().pollEnd.isBefore(b.getEvent().pollEnd)) {
+              return -1;
+            } else if (b.getEvent().pollEnd.isBefore(a.getEvent().pollEnd)) {
+              return 1;
+            } else {
+              //same time, give definitive sort based on ids
+              return a.getEventId().compareTo(b.getEventId());
+            }
           } else if (a.getEventMode() == EventsManager.occurringMode) {
-            return b
-                    .getEvent()
-                    .eventStartDateTime
-                    .isBefore(a.getEvent().eventStartDateTime)
-                ? 1
-                : -1;
+            if (a
+                .getEvent()
+                .eventStartDateTime
+                .isBefore(b.getEvent().eventStartDateTime)) {
+              return -1;
+            } else if (b
+                .getEvent()
+                .eventStartDateTime
+                .isBefore(a.getEvent().eventStartDateTime)) {
+              return 1;
+            } else {
+              //same time, give definitive sort based on ids
+              return a.getEventId().compareTo(b.getEventId());
+            }
           } else {
-            // event is in closed mode. we want the most recent times here otherwise the first event would always be at the top
-            return a
-                    .getEvent()
-                    .eventStartDateTime
-                    .isBefore(b.getEvent().eventStartDateTime)
-                ? 1
-                : -1;
+            //event is in closed mode. we want the most recent times here
+            // otherwise the first event would always be at the top
+            if (a
+                .getEvent()
+                .eventStartDateTime
+                .isBefore(b.getEvent().eventStartDateTime)) {
+              return 1;
+            } else if (b
+                .getEvent()
+                .eventStartDateTime
+                .isBefore(a.getEvent().eventStartDateTime)) {
+              return -1;
+            } else {
+              //same time, give definitive sort based on ids
+              return a.getEventId().compareTo(b.getEventId());
+            }
           }
         }
       });

--- a/front_end_pocket_poll/lib/groups_widgets/group_page.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_page.dart
@@ -78,6 +78,10 @@ class _GroupPageState extends State<GroupPage>
     EventsList.eventsTypeOccurring: new Map<int, List<String>>()
   };
 
+  //This tracks the max scroll extents of the lists as they grow up until the
+  // list reaches the max batch in memory size. This allows us to load the list
+  // in the correct position when destroying events at the top of the list to
+  // account for the max memory size being hit
   final Map<int, double> eventTypesToPreviousMaxScrollExtents = {
     EventsList.eventsTypeNew: null,
     EventsList.eventsTypeVoting: null,
@@ -86,6 +90,8 @@ class _GroupPageState extends State<GroupPage>
     EventsList.eventsTypeOccurring: null
   };
 
+  //This tracks the scroll extent of a fully filled up list. This is used to
+  // calculate the appropriate offset when loading in the up direction.
   final Map<int, double> eventTypesToMaxScrollExtentOfMaxBatches = {
     EventsList.eventsTypeNew: null,
     EventsList.eventsTypeVoting: null,

--- a/front_end_pocket_poll/lib/groups_widgets/group_page.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_page.dart
@@ -660,7 +660,6 @@ class _GroupPageState extends State<GroupPage>
       // the first batch after the max in memory. To make scrolling back up work
       // we save the max scroll extent of the page will full batches loaded
       if (batchIndex == GroupPage.maxEventBatchesInMemory) {
-        print("setting the thing");
         this.eventTypesToMaxScrollExtentOfMaxBatches[batchType] =
             maxScrollExtent;
       }

--- a/front_end_pocket_poll/lib/groups_widgets/group_page.dart
+++ b/front_end_pocket_poll/lib/groups_widgets/group_page.dart
@@ -658,7 +658,8 @@ class _GroupPageState extends State<GroupPage>
 
       //batchIndex starts at 0, batchIndex equal to max means that we're loading
       // the first batch after the max in memory. To make scrolling back up work
-      // we save the max scroll extent of the page will full batches loaded
+      // we save the max scroll extent of the page now since we know it has full
+      // batches loaded
       if (batchIndex == GroupPage.maxEventBatchesInMemory) {
         this.eventTypesToMaxScrollExtentOfMaxBatches[batchType] =
             maxScrollExtent;

--- a/front_end_pocket_poll/lib/models/event_card_interface.dart
+++ b/front_end_pocket_poll/lib/models/event_card_interface.dart
@@ -4,4 +4,6 @@ class EventCardInterface{
   int getEventMode() {}
 
   Event getEvent(){}
+
+  String getEventId(){}
 }

--- a/front_end_pocket_poll/lib/utilities/sorter.dart
+++ b/front_end_pocket_poll/lib/utilities/sorter.dart
@@ -1,6 +1,8 @@
 import 'package:front_end_pocket_poll/categories_widgets/choice_row.dart';
+import 'package:front_end_pocket_poll/imports/events_manager.dart';
 import 'package:front_end_pocket_poll/imports/globals.dart';
 import 'package:front_end_pocket_poll/models/category.dart';
+import 'package:front_end_pocket_poll/models/event_card_interface.dart';
 import 'package:front_end_pocket_poll/models/group_interface.dart';
 import 'package:front_end_pocket_poll/models/user_group.dart';
 
@@ -75,5 +77,73 @@ class Sorter {
   static void sortCategoriesByAlphaDescending(List<Category> categories) {
     categories.sort((a, b) =>
         b.categoryName.toLowerCase().compareTo(a.categoryName.toLowerCase()));
+  }
+
+  // sorts a list of EventCardInterfaces based on the event state
+  static void sortEventCardInterfaces(
+      final List<EventCardInterface> eventCardInterfaces) {
+    eventCardInterfaces.sort((a, b) {
+      if (a.getEventMode() > b.getEventMode()) {
+        return -1;
+      } else if (b.getEventMode() > a.getEventMode()) {
+        return 1;
+      } else {
+        //cards are same priority
+        if (a.getEventMode() == EventsManager.considerMode) {
+          if (a.getEvent().pollBegin.isBefore(b.getEvent().pollBegin)) {
+            return -1;
+          } else if (b
+              .getEvent()
+              .pollBegin
+              .isBefore(a.getEvent().pollBegin)) {
+            return 1;
+          } else {
+            //same time, give definitive sort based on ids
+            return a.getEventId().compareTo(b.getEventId());
+          }
+        } else if (a.getEventMode() == EventsManager.votingMode) {
+          if (a.getEvent().pollEnd.isBefore(b.getEvent().pollEnd)) {
+            return -1;
+          } else if (b.getEvent().pollEnd.isBefore(a.getEvent().pollEnd)) {
+            return 1;
+          } else {
+            //same time, give definitive sort based on ids
+            return a.getEventId().compareTo(b.getEventId());
+          }
+        } else if (a.getEventMode() == EventsManager.occurringMode) {
+          if (a
+              .getEvent()
+              .eventStartDateTime
+              .isBefore(b.getEvent().eventStartDateTime)) {
+            return -1;
+          } else if (b
+              .getEvent()
+              .eventStartDateTime
+              .isBefore(a.getEvent().eventStartDateTime)) {
+            return 1;
+          } else {
+            //same time, give definitive sort based on ids
+            return a.getEventId().compareTo(b.getEventId());
+          }
+        } else {
+          //event is in closed mode. we want the most recent times here
+          // otherwise the first event would always be at the top
+          if (a
+              .getEvent()
+              .eventStartDateTime
+              .isBefore(b.getEvent().eventStartDateTime)) {
+            return 1;
+          } else if (b
+              .getEvent()
+              .eventStartDateTime
+              .isBefore(a.getEvent().eventStartDateTime)) {
+            return -1;
+          } else {
+            //same time, give definitive sort based on ids
+            return a.getEventId().compareTo(b.getEventId());
+          }
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
#### Front End
* I added a snack bar loading indicator on the events list when the load next batch was triggered.
* I fixed the keyboard not opening on the create/edit category pages by putting the request focus in another post callback frame.
* I made the short lists on the events list always scroll-able using always scroll-able physics.
* I fixed the bug where scrolling up from the bottom of an incomplete batch would cause a jump. I did this by saving the maxScrollExtent of the page when the first batch past the maxBatchesInMemory was being loaded. To exceed the max batches in memory necessitates that there be full batches loaded on the page. This means we have the pixel size of a full list. By saving that, we don't have to worry about incomplete batches later on that will break the max scroll extent.

#### Front End and Back End
When the voting start/end or event start times for two events equal one another, their sorts become ambiguous. I.e. a before b is the same as b before a. This makes it where events can hop around in the list when the list gets reloaded (i.e. when a new batch is loaded). I fixed the ambiguity of the sorts by comparing event ids of events since these must be unique.

## Testing
I clicked around a bunch and ran the behavioral tests. I deployed my code to my lambda to be double sure that I wasn't breaking anything.