### PR TITLE
removed s3 from warming because money

### DIFF
--- a/backEnd/src/main/java/handlers/WarmingHandler.java
+++ b/backEnd/src/main/java/handlers/WarmingHandler.java
@@ -37,7 +37,9 @@ public class WarmingHandler implements ApiRequestHandler {
 
     try {
       this.dbAccessManager.describeTables();
-      this.s3AccessManager.imageBucketExists();
+      // this line counts as an s3 get request which is consuming our s3 free tier limit
+      // there are few cases where a warm connection to s3 is necessary and we have few users
+//      this.s3AccessManager.imageBucketExists();
       this.snsAccessManager.getPlatformAttributes(Config.PUSH_SNS_PLATFORM_ARN);
 
       resultStatus = ResultStatus.successful("Endpoints warmed.");

--- a/backEnd/src/test/java/handlers/WarmingHandlerTest.java
+++ b/backEnd/src/test/java/handlers/WarmingHandlerTest.java
@@ -54,7 +54,7 @@ public class WarmingHandlerTest {
 
     assertTrue(resultStatus.success);
     verify(this.dbAccessManager, times(1)).describeTables();
-    verify(this.s3AccessManager, times(1)).imageBucketExists();
+    verify(this.s3AccessManager, times(0)).imageBucketExists();
     verify(this.snsAccessManager, times(1)).getPlatformAttributes(Config.PUSH_SNS_PLATFORM_ARN);
     verify(this.metrics, times(1)).commonClose(true);
   }


### PR DESCRIPTION
## Summary
Our warming every 5 minutes is running up out our s3 get request free tier limits. This is costing a small amount every month, but never the less I'd rather not (There are only a few use cases for warming s3 and we don't have a lot of users so I don't think we're losing much). I've commented out the line that does the warming for now.

## Testing
I've already deployed the code and made sure the values are decreasing. This is just for formalities and nostalgia 😢 